### PR TITLE
Remove spec warnings

### DIFF
--- a/spec/rubocop/cop/rails/bulk_change_table_spec.rb
+++ b/spec/rubocop/cop/rails/bulk_change_table_spec.rb
@@ -3,8 +3,6 @@
 RSpec.describe RuboCop::Cop::Rails::BulkChangeTable, :config do
   subject(:cop) { described_class.new(config) }
 
-  let(:rails_version) { 5.2 }
-
   shared_examples 'offense' do
     it 'registers an offense when including combinable transformations' do
       expect_offense(<<-RUBY.strip_indent)
@@ -373,9 +371,13 @@ RSpec.describe RuboCop::Cop::Rails::BulkChangeTable, :config do
       }
     end
 
-    it_behaves_like 'offense'
-    it_behaves_like 'no offense for mysql'
-    it_behaves_like 'offense for postgresql'
+    context 'with Rails 5.2' do
+      let(:rails_version) { 5.2 }
+
+      it_behaves_like 'offense'
+      it_behaves_like 'no offense for mysql'
+      it_behaves_like 'offense for postgresql'
+    end
 
     context 'with Rails 5.1' do
       let(:rails_version) { 5.1 }
@@ -419,7 +421,17 @@ RSpec.describe RuboCop::Cop::Rails::BulkChangeTable, :config do
         }
       end
 
-      it_behaves_like 'offense for postgresql'
+      context 'with Rails 5.2' do
+        let(:rails_version) { 5.2 }
+
+        it_behaves_like 'offense for postgresql'
+      end
+
+      context 'with Rails 5.1' do
+        let(:rails_version) { 5.1 }
+
+        it_behaves_like 'no offense for postgresql'
+      end
     end
 
     context 'invalid (e.g. ERB)' do

--- a/spec/rubocop/cop/rails/save_bang_spec.rb
+++ b/spec/rubocop/cop/rails/save_bang_spec.rb
@@ -497,9 +497,9 @@ RSpec.describe RuboCop::Cop::Rails::SaveBang, :config do
   end
 
   described_class::MODIFY_PERSIST_METHODS.each do |method|
-    let(:cop_config) { { 'AllowImplicitReturn' => true } }
-
     context method.to_s do
+      let(:cop_config) { { 'AllowImplicitReturn' => true } }
+
       it_behaves_like('checks_common_offense', method)
       it_behaves_like('checks_variable_return_use_offense', method, true)
       it_behaves_like('check_implicit_return', method, true)
@@ -535,9 +535,9 @@ RSpec.describe RuboCop::Cop::Rails::SaveBang, :config do
   end
 
   described_class::CREATE_PERSIST_METHODS.each do |method|
-    let(:cop_config) { { 'AllowImplicitReturn' => true } }
-
     context method.to_s do
+      let(:cop_config) { { 'AllowImplicitReturn' => true } }
+
       it_behaves_like('checks_common_offense', method)
       it_behaves_like('checks_variable_return_use_offense', method, false)
       it_behaves_like('checks_create_offense', method)


### PR DESCRIPTION
The `let`s :rails_version and :cop_config should only be overwritten within a `context`. Overwriting them in global scope makes Ruby emit a warning.

These warnings are now no longer present in output on CI:
```
/home/ubuntu/rubocop-rails/vendor/bundle/ruby/2.2.0/gems/rspec-core-3.8.0/lib/rspec/core/memoized_helpers.rb:291: warning: method redefined; discarding old rails_version
/home/ubuntu/rubocop-rails/vendor/bundle/ruby/2.2.0/gems/rubocop-0.59.2/lib/rubocop/rspec/cop_helper.rb:11: warning: previous definition of rails_version was here
/home/ubuntu/rubocop-rails/vendor/bundle/ruby/2.2.0/gems/rspec-core-3.8.0/lib/rspec/core/memoized_helpers.rb:298: warning: method redefined; discarding old rails_version
/home/ubuntu/rubocop-rails/vendor/bundle/ruby/2.2.0/gems/rspec-core-3.8.0/lib/rspec/core/memoized_helpers.rb:298: warning: previous definition of rails_version was here
/home/ubuntu/rubocop-rails/vendor/bundle/ruby/2.2.0/gems/rspec-core-3.8.0/lib/rspec/core/memoized_helpers.rb:291: warning: method redefined; discarding old cop_config
/home/ubuntu/rubocop-rails/spec/rubocop/cop/rails/save_bang_spec.rb:500: warning: previous definition of cop_config was here
/home/ubuntu/rubocop-rails/vendor/bundle/ruby/2.2.0/gems/rspec-core-3.8.0/lib/rspec/core/memoized_helpers.rb:298: warning: method redefined; discarding old cop_config
/home/ubuntu/rubocop-rails/vendor/bundle/ruby/2.2.0/gems/rspec-core-3.8.0/lib/rspec/core/memoized_helpers.rb:298: warning: previous definition of cop_config was here
/home/ubuntu/rubocop-rails/vendor/bundle/ruby/2.2.0/gems/rspec-core-3.8.0/lib/rspec/core/memoized_helpers.rb:291: warning: method redefined; discarding old cop_config
/home/ubuntu/rubocop-rails/spec/rubocop/cop/rails/save_bang_spec.rb:500: warning: previous definition of cop_config was here
/home/ubuntu/rubocop-rails/vendor/bundle/ruby/2.2.0/gems/rspec-core-3.8.0/lib/rspec/core/memoized_helpers.rb:298: warning: method redefined; discarding old cop_config
/home/ubuntu/rubocop-rails/vendor/bundle/ruby/2.2.0/gems/rspec-core-3.8.0/lib/rspec/core/memoized_helpers.rb:298: warning: previous definition of cop_config was here
/home/ubuntu/rubocop-rails/vendor/bundle/ruby/2.2.0/gems/rspec-core-3.8.0/lib/rspec/core/memoized_helpers.rb:291: warning: method redefined; discarding old cop_config
/home/ubuntu/rubocop-rails/spec/rubocop/cop/rails/save_bang_spec.rb:500: warning: previous definition of cop_config was here
/home/ubuntu/rubocop-rails/vendor/bundle/ruby/2.2.0/gems/rspec-core-3.8.0/lib/rspec/core/memoized_helpers.rb:298: warning: method redefined; discarding old cop_config
/home/ubuntu/rubocop-rails/vendor/bundle/ruby/2.2.0/gems/rspec-core-3.8.0/lib/rspec/core/memoized_helpers.rb:298: warning: previous definition of cop_config was here
/home/ubuntu/rubocop-rails/vendor/bundle/ruby/2.2.0/gems/rspec-core-3.8.0/lib/rspec/core/memoized_helpers.rb:291: warning: method redefined; discarding old cop_config
/home/ubuntu/rubocop-rails/spec/rubocop/cop/rails/save_bang_spec.rb:500: warning: previous definition of cop_config was here
/home/ubuntu/rubocop-rails/vendor/bundle/ruby/2.2.0/gems/rspec-core-3.8.0/lib/rspec/core/memoized_helpers.rb:298: warning: method redefined; discarding old cop_config
/home/ubuntu/rubocop-rails/vendor/bundle/ruby/2.2.0/gems/rspec-core-3.8.0/lib/rspec/core/memoized_helpers.rb:298: warning: previous definition of cop_config was here
/home/ubuntu/rubocop-rails/vendor/bundle/ruby/2.2.0/gems/rspec-core-3.8.0/lib/rspec/core/memoized_helpers.rb:291: warning: method redefined; discarding old cop_config
/home/ubuntu/rubocop-rails/spec/rubocop/cop/rails/save_bang_spec.rb:538: warning: previous definition of cop_config was here
/home/ubuntu/rubocop-rails/vendor/bundle/ruby/2.2.0/gems/rspec-core-3.8.0/lib/rspec/core/memoized_helpers.rb:298: warning: method redefined; discarding old cop_config
/home/ubuntu/rubocop-rails/vendor/bundle/ruby/2.2.0/gems/rspec-core-3.8.0/lib/rspec/core/memoized_helpers.rb:298: warning: previous definition of cop_config was here
/home/ubuntu/rubocop-rails/vendor/bundle/ruby/2.2.0/gems/rspec-core-3.8.0/lib/rspec/core/memoized_helpers.rb:291: warning: method redefined; discarding old cop_config
/home/ubuntu/rubocop-rails/spec/rubocop/cop/rails/save_bang_spec.rb:538: warning: previous definition of cop_config was here
/home/ubuntu/rubocop-rails/vendor/bundle/ruby/2.2.0/gems/rspec-core-3.8.0/lib/rspec/core/memoized_helpers.rb:298: warning: method redefined; discarding old cop_config
/home/ubuntu/rubocop-rails/vendor/bundle/ruby/2.2.0/gems/rspec-core-3.8.0/lib/rspec/core/memoized_helpers.rb:298: warning: previous definition of cop_config was here
```