### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+sudo: false
+cache: bundler
+language: ruby
+dist: trusty
+rvm:
+  - jruby-9.2.5.0
+  - jruby-head
+  - 2.2.10
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
+  - ruby-head
+env:
+  global:
+    - JRUBY_OPTS='--debug -J-Xmx1000M' # get more accurate coverage data in JRuby
+    # Travis CI container has two cores, but Ruby can see 32 cores unfortunately.
+    # See https://github.com/rubocop-hq/rubocop/pull/5719
+    #     https://docs.travis-ci.com/user/reference/overview/#Virtualisation-Environment-vs-Operating-System
+    - TEST_QUEUE_WORKERS=2
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+    - rvm: jruby-head
+  fast_finish: true
+before_install:
+  - gem update --system
+  - gem update --remote bundler
+install:
+  - bundle install --retry=3


### PR DESCRIPTION
This PR adds .travis.yml to RuboCop Rails repository.

This is based on the settings used in RuboCop 0.59.0.
https://github.com/rubocop-hq/rubocop/blob/v0.59.0/.travis.yml

Since RuboCop Core has switched from Travis CI to CircleCI, there is a possibility that it will switch to CircleCI in the future.