### PR TITLE
Fix a build error for Ruby 2.2 matrix on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ matrix:
     - rvm: jruby-head
   fast_finish: true
 before_install:
-  - gem update --system
   - gem update --remote bundler
 install:
   - bundle install --retry=3


### PR DESCRIPTION
RubyGems 3.0.0 requires Ruby 2.3.0 or higher.
https://github.com/rubygems/rubygems/blob/v3.0.0/rubygems-update.gemspec#L32

This PR fixes the following build error.

```console
$ gem update --system
Updating rubygems-update
Fetching: rubygems-update-3.0.0.gem (100%)
ERROR:  Error installing rubygems-update:
        rubygems-update requires Ruby version >= 2.3.0.
ERROR:  While executing gem ... (NoMethodError)
    undefined method `version' for nil:NilClass
The command "gem update --system" failed and exited with 1 during .
```

https://travis-ci.org/rubocop-hq/rubocop-rails/jobs/471037127#L480-L487