### PR TITLE
CI against Ruby 2.6.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,9 @@ workflows:
           name: Ruby 2.5
           image: circleci/ruby:2.5
       - rake_default:
+          name: Ruby 2.6
+          image: circleci/ruby:2.6
+      - rake_default:
           name: Ruby HEAD
           image: rubocophq/circleci-ruby-snapshot:latest # Nightly snapshot build
       - rake_default:


### PR DESCRIPTION
Ruby 2.6.0 has been released and this Ruby version is available on CircleCI.

- https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/
- https://hub.docker.com/r/circleci/ruby/tags/