### PR TITLE
Add `rack` to runtime dependency

### DIFF
--- a/lib/rubocop-rails.rb
+++ b/lib/rubocop-rails.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rubocop'
+require 'rack/utils'
 
 require_relative 'rubocop/rails/version'
 require_relative 'rubocop/cop/rails_cops'

--- a/lib/rubocop/cop/rails/http_status.rb
+++ b/lib/rubocop/cop/rails/http_status.rb
@@ -32,13 +32,6 @@ module RuboCop
       #   redirect_to root_url, status: 301
       #
       class HttpStatus < Cop
-        begin
-          require 'rack/utils'
-          RACK_LOADED = true
-        rescue LoadError
-          RACK_LOADED = false
-        end
-
         include ConfigurableEnforcedStyle
 
         def_node_matcher :http_status, <<-PATTERN
@@ -62,10 +55,6 @@ module RuboCop
 
             add_offense(checker.node, message: checker.message)
           end
-        end
-
-        def support_autocorrect?
-          RACK_LOADED
         end
 
         def autocorrect(node)
@@ -110,11 +99,7 @@ module RuboCop
           end
 
           def message
-            if RACK_LOADED
-              format(MSG, prefer: preferred_style, current: number.to_s)
-            else
-              DEFAULT_MSG
-            end
+            format(MSG, prefer: preferred_style, current: number.to_s)
           end
 
           def preferred_style
@@ -155,11 +140,7 @@ module RuboCop
           end
 
           def message
-            if RACK_LOADED
-              format(MSG, prefer: preferred_style, current: symbol.inspect)
-            else
-              DEFAULT_MSG
-            end
+            format(MSG, prefer: preferred_style, current: symbol.inspect)
           end
 
           def preferred_style

--- a/rubocop-rails.gemspec
+++ b/rubocop-rails.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
     'bug_tracker_uri' => 'https://github.com/rubocop-hq/rubocop-rails/issues'
   }
 
+  s.add_runtime_dependency 'rack', '>= 2.0'
   s.add_runtime_dependency 'rubocop', '>= 0.58.0'
-  s.add_development_dependency('rack', '>= 2.0')
 end
 # rubocop:enable Metrics/BlockLength

--- a/spec/rubocop/cop/rails/http_status_spec.rb
+++ b/spec/rubocop/cop/rails/http_status_spec.rb
@@ -49,30 +49,6 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
         redirect_to root_url, status: 550
       RUBY
     end
-
-    context 'when rack is not loaded' do
-      before { stub_const("#{described_class}::RACK_LOADED", false) }
-
-      it 'registers an offense and does not correct using numeric value' do
-        expect_offense(<<-RUBY)
-          render :foo, status: 200
-                               ^^^ Prefer `symbolic` over `numeric` to define HTTP status code.
-          render json: { foo: 'bar' }, status: 404
-                                               ^^^ Prefer `symbolic` over `numeric` to define HTTP status code.
-          render plain: 'foo/bar', status: 304
-                                           ^^^ Prefer `symbolic` over `numeric` to define HTTP status code.
-          redirect_to root_url, status: 301
-                                        ^^^ Prefer `symbolic` over `numeric` to define HTTP status code.
-        RUBY
-
-        expect_correction(<<-RUBY)
-          render :foo, status: 200
-          render json: { foo: 'bar' }, status: 404
-          render plain: 'foo/bar', status: 304
-          redirect_to root_url, status: 301
-        RUBY
-      end
-    end
   end
 
   context 'when EnforcedStyle is `numeric`' do
@@ -120,23 +96,6 @@ RSpec.describe RuboCop::Cop::Rails::HttpStatus, :config do
         render :foo, status: :missing
         render :foo, status: :redirect
       RUBY
-    end
-
-    context 'when rack is not loaded' do
-      before { stub_const("#{described_class}::RACK_LOADED", false) }
-
-      it 'registers an offense and corrects using symbolic value' do
-        expect_offense(<<-RUBY)
-          render :foo, status: :ok
-                               ^^^ Prefer `numeric` over `symbolic` to define HTTP status code.
-          render json: { foo: 'bar' }, status: :not_found
-                                               ^^^^^^^^^^ Prefer `numeric` over `symbolic` to define HTTP status code.
-          render plain: 'foo/bar', status: :not_modified
-                                           ^^^^^^^^^^^^^ Prefer `numeric` over `symbolic` to define HTTP status code.
-          redirect_to root_url, status: :moved_permanently
-                                        ^^^^^^^^^^^^^^^^^^ Prefer `numeric` over `symbolic` to define HTTP status code.
-        RUBY
-      end
     end
   end
 end


### PR DESCRIPTION
I'm not sure the status of this repository. So if this pull request is not mergeable now, I think we keep open this pull request.






`Rails/HttpStatus` cop uses rack gem as an additional dependency to display more descriptive offense messages. The runtime dependencies do not include rack because RuboCop needs the gem only for the cop.

I think we can add rack to runtime dependencies after separating `rubocop-rails` gem.
`rubocop` is used without rack sometimes, but `rubocop-rails` gem will be used with rails gem in most cases, so the environment includes rack already.
If we add rack, installed gems does not increase. 