### PR TITLE
Add metadata to default.yml

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -13,6 +13,7 @@ AllCops:
 Rails/ActionFilter:
   Description: 'Enforces consistent use of action filter methods.'
   Enabled: true
+  VersionAdded: '0.19'
   EnforcedStyle: action
   SupportedStyles:
     - action
@@ -26,6 +27,7 @@ Rails/ActiveRecordAliases:
                   Use `update` instead of `update_attributes`.
                   Use `update!` instead of `update_attributes!`.
   Enabled: true
+  VersionAdded: '0.53'
 
 Rails/ActiveSupportAliases:
   Description: >-
@@ -33,18 +35,22 @@ Rails/ActiveSupportAliases:
                   `String#starts_with?`, `String#ends_with?`,
                   `Array#append`, `Array#prepend`.
   Enabled: true
+  VersionAdded: '0.48'
 
 Rails/ApplicationJob:
   Description: 'Check that jobs subclass ApplicationJob.'
   Enabled: true
+  VersionAdded: '0.49'
 
 Rails/ApplicationRecord:
   Description: 'Check that models subclass ApplicationRecord.'
   Enabled: true
+  VersionAdded: '0.49'
 
 Rails/AssertNot:
   Description: 'Use `assert_not` instead of `assert !`.'
   Enabled: true
+  VersionAdded: '0.56'
   Include:
     - '**/test/**/*'
 
@@ -53,10 +59,12 @@ Rails/BelongsTo:
                   Use `optional: true` instead of `required: false` for
                   `belongs_to` relations'
   Enabled: true
+  VersionAdded: '0.62'
 
 Rails/Blank:
   Description: 'Enforces use of `blank?`.'
   Enabled: true
+  VersionAdded: '0.48'
   # Convert usages of `nil? || empty?` to `blank?`
   NilOrEmpty: true
   # Convert usages of `!present?` to `blank?`
@@ -67,6 +75,7 @@ Rails/Blank:
 Rails/BulkChangeTable:
   Description: 'Check whether alter queries are combinable.'
   Enabled: true
+  VersionAdded: '0.57'
   Database: null
   SupportedDatabases:
     - mysql
@@ -79,6 +88,7 @@ Rails/CreateTableWithTimestamps:
                   Checks the migration for which timestamps are not included
                   when creating a new table.
   Enabled: true
+  VersionAdded: '0.52'
   Include:
     - db/migrate/*.rb
 
@@ -87,6 +97,8 @@ Rails/Date:
                   Checks the correct usage of date aware methods,
                   such as Date.today, Date.current etc.
   Enabled: true
+  VersionAdded: '0.30'
+  VersionChanged: '0.33'
   # The value `strict` disallows usage of `Date.today`, `Date.current`,
   # `Date#to_time` etc.
   # The value `flexible` allows usage of `Date.current`, `Date.yesterday`, etc
@@ -100,6 +112,8 @@ Rails/Date:
 Rails/Delegate:
   Description: 'Prefer delegate method for delegations.'
   Enabled: true
+  VersionAdded: '0.21'
+  VersionChanged: '0.50'
   # When set to true, using the target object as a prefix of the
   # method name without using the `delegate` method will be a
   # violation. When set to false, this case is legal.
@@ -108,23 +122,27 @@ Rails/Delegate:
 Rails/DelegateAllowBlank:
   Description: 'Do not use allow_blank as an option to delegate.'
   Enabled: true
+  VersionAdded: '0.44'
 
 Rails/DynamicFindBy:
   Description: 'Use `find_by` instead of dynamic `find_by_*`.'
   StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#find_by'
   Enabled: true
+  VersionAdded: '0.44'
   Whitelist:
     - find_by_sql
 
 Rails/EnumUniqueness:
   Description: 'Avoid duplicate integers in hash-syntax `enum` declaration.'
   Enabled: true
+  VersionAdded: '0.46'
   Include:
     - app/models/**/*.rb
 
 Rails/EnvironmentComparison:
   Description: "Favor `Rails.env.production?` over `Rails.env == 'production'`"
   Enabled: true
+  VersionAdded: '0.52'
 
 Rails/Exit:
   Description: >-
@@ -132,6 +150,7 @@ Rails/Exit:
                   application or library code outside of Rake files to avoid
                   exits during unit testing or running in production.
   Enabled: true
+  VersionAdded: '0.41'
   Include:
     - app/**/*.rb
     - config/**/*.rb
@@ -142,6 +161,8 @@ Rails/Exit:
 Rails/FilePath:
   Description: 'Use `Rails.root.join` for file path joining.'
   Enabled: true
+  VersionAdded: '0.47'
+  VersionChanged: '0.57'
   EnforcedStyle: arguments
   SupportedStyles:
     - slashes
@@ -151,6 +172,7 @@ Rails/FindBy:
   Description: 'Prefer find_by over where.first.'
   StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#find_by'
   Enabled: true
+  VersionAdded: '0.30'
   Include:
     - app/models/**/*.rb
 
@@ -158,6 +180,7 @@ Rails/FindEach:
   Description: 'Prefer all.find_each over all.find.'
   StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#find-each'
   Enabled: true
+  VersionAdded: '0.30'
   Include:
     - app/models/**/*.rb
 
@@ -165,6 +188,7 @@ Rails/HasAndBelongsToMany:
   Description: 'Prefer has_many :through to has_and_belongs_to_many.'
   StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#has-many-through'
   Enabled: true
+  VersionAdded: '0.12'
   Include:
     - app/models/**/*.rb
 
@@ -172,18 +196,21 @@ Rails/HasManyOrHasOneDependent:
   Description: 'Define the dependent option to the has_many and has_one associations.'
   StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#has_many-has_one-dependent-option'
   Enabled: true
+  VersionAdded: '0.50'
   Include:
     - app/models/**/*.rb
 
 Rails/HelperInstanceVariable:
   Description: 'Do not use instance variables in helpers'
   Enabled: true
+  VersionAdded: '2.0'
   Include:
     - app/helpers/**/*.rb
 
 Rails/HttpPositionalArguments:
   Description: 'Use keyword arguments instead of positional arguments in http method calls.'
   Enabled: true
+  VersionAdded: '0.44'
   Include:
     - 'spec/**/*'
     - 'test/**/*'
@@ -191,6 +218,7 @@ Rails/HttpPositionalArguments:
 Rails/HttpStatus:
   Description: 'Enforces use of symbolic or numeric value to define HTTP status.'
   Enabled: true
+  VersionAdded: '0.54'
   EnforcedStyle: symbolic
   SupportedStyles:
     - numeric
@@ -200,12 +228,14 @@ Rails/IgnoredSkipActionFilterOption:
   Description: 'Checks that `if` and `only` (or `except`) are not used together as options of `skip_*` action filter.'
   Reference: 'https://api.rubyonrails.org/classes/AbstractController/Callbacks/ClassMethods.html#method-i-_normalize_callback_options'
   Enabled: true
+  VersionAdded: '0.63'
   Include:
     - app/controllers/**/*.rb
 
 Rails/InverseOf:
   Description: 'Checks for associations where the inverse cannot be determined automatically.'
   Enabled: true
+  VersionAdded: '0.52'
   Include:
     - app/models/**/*.rb
 
@@ -213,6 +243,7 @@ Rails/LexicallyScopedActionFilter:
   Description: "Checks that methods specified in the filter's `only` or `except` options are explicitly defined in the controller."
   StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#lexically-scoped-action-filter'
   Enabled: true
+  VersionAdded: '0.52'
   Include:
     - app/controllers/**/*.rb
 
@@ -220,16 +251,20 @@ Rails/LinkToBlank:
   Description: 'Checks that `link_to` with a `target: "_blank"` have a `rel: "noopener"` option passed to them.'
   Reference: https://mathiasbynens.github.io/rel-noopener/
   Enabled: true
+  VersionAdded: '0.62'
 
 Rails/NotNullColumn:
   Description: 'Do not add a NOT NULL column without a default value'
   Enabled: true
+  VersionAdded: '0.43'
   Include:
     - db/migrate/*.rb
 
 Rails/Output:
   Description: 'Checks for calls to puts, print, etc.'
   Enabled: true
+  VersionAdded: '0.15'
+  VersionChanged: '0.19'
   Include:
     - app/**/*.rb
     - config/**/*.rb
@@ -239,18 +274,22 @@ Rails/Output:
 Rails/OutputSafety:
   Description: 'The use of `html_safe` or `raw` may be a security risk.'
   Enabled: true
+  VersionAdded: '0.41'
 
 Rails/PluralizationGrammar:
   Description: 'Checks for incorrect grammar when using methods like `3.day.ago`.'
   Enabled: true
+  VersionAdded: '0.35'
 
 Rails/Presence:
   Description: 'Checks code that can be written more easily using `Object#presence` defined by Active Support.'
   Enabled: true
+  VersionAdded: '0.52'
 
 Rails/Present:
   Description: 'Enforces use of `present?`.'
   Enabled: true
+  VersionAdded: '0.48'
   # Convert usages of `!nil? && !empty?` to `present?`
   NotNilAndNotEmpty: true
   # Convert usages of `!blank?` to `present?`
@@ -264,31 +303,39 @@ Rails/ReadWriteAttribute:
                  write_attribute(:attr, val).
   StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#read-attribute'
   Enabled: true
+  VersionAdded: '0.20'
+  VersionChanged: '0.29'
   Include:
     - app/models/**/*.rb
 
 Rails/RedundantReceiverInWithOptions:
   Description: 'Checks for redundant receiver in `with_options`.'
   Enabled: true
+  VersionAdded: '0.52'
 
 Rails/ReflectionClassName:
   Description: 'Use a string for `class_name` option value in the definition of a reflection.'
   Enabled: true
+  VersionAdded: '0.64'
 
 Rails/RefuteMethods:
   Description: 'Use `assert_not` methods instead of `refute` methods.'
   Enabled: true
+  VersionAdded: '0.56'
   Include:
     - '**/test/**/*'
 
 Rails/RelativeDateConstant:
   Description: 'Do not assign relative date to constants.'
   Enabled: true
+  VersionAdded: '0.48'
+  VersionChanged: '0.59'
   AutoCorrect: false
 
 Rails/RequestReferer:
   Description: 'Use consistent syntax for request.referer.'
   Enabled: true
+  VersionAdded: '0.41'
   EnforcedStyle: referer
   SupportedStyles:
     - referer
@@ -299,12 +346,14 @@ Rails/ReversibleMigration:
   StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#reversible-migration'
   Reference: 'https://api.rubyonrails.org/classes/ActiveRecord/Migration/CommandRecorder.html'
   Enabled: true
+  VersionAdded: '0.47'
   Include:
     - db/migrate/*.rb
 
 Rails/SafeNavigation:
   Description: "Use Ruby's safe navigation operator (`&.`) instead of `try!`"
   Enabled: true
+  VersionAdded: '0.43'
   # This will convert usages of `try` to use safe navigation as well as `try!`.
   # `try` and `try!` work slightly differently. `try!` and safe navigation will
   # both raise a `NoMethodError` if the receiver of the method call does not
@@ -315,12 +364,15 @@ Rails/SaveBang:
   Description: 'Identifies possible cases where Active Record save! or related should be used.'
   StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#save-bang'
   Enabled: false
+  VersionAdded: '0.42'
+  VersionChanged: '0.59'
   AllowImplicitReturn: true
   AllowedReceivers: []
 
 Rails/ScopeArgs:
   Description: 'Checks the arguments of ActiveRecord scopes.'
   Enabled: true
+  VersionAdded: '0.19'
   Include:
     - app/models/**/*.rb
 
@@ -330,6 +382,8 @@ Rails/SkipsModelValidations:
                  See reference for more information.
   Reference: 'https://guides.rubyonrails.org/active_record_validations.html#skipping-validations'
   Enabled: true
+  VersionAdded: '0.47'
+  VersionChanged: '0.60'
   Blacklist:
     - decrement!
     - decrement_counter
@@ -349,6 +403,8 @@ Rails/TimeZone:
   StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#time'
   Reference: 'http://danilenko.org/2012/7/6/rails_timezones'
   Enabled: true
+  VersionAdded: '0.30'
+  VersionChanged: '0.33'
   # The value `strict` means that `Time` should be used with `zone`.
   # The value `flexible` allows usage of `in_time_zone` instead of `zone`.
   EnforcedStyle: flexible
@@ -359,6 +415,8 @@ Rails/TimeZone:
 Rails/UniqBeforePluck:
   Description: 'Prefer the use of uniq or distinct before pluck.'
   Enabled: true
+  VersionAdded: '0.40'
+  VersionChanged: '0.47'
   EnforcedStyle: conservative
   SupportedStyles:
     - conservative
@@ -368,6 +426,7 @@ Rails/UniqBeforePluck:
 Rails/UnknownEnv:
   Description: 'Use correct environment name.'
   Enabled: true
+  VersionAdded: '0.51'
   Environments:
     - development
     - test
@@ -376,5 +435,7 @@ Rails/UnknownEnv:
 Rails/Validation:
   Description: 'Use validates :attribute, hash of validations.'
   Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.41'
   Include:
     - app/models/**/*.rb

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -2,9 +2,9 @@
 
 ## Rails/ActionFilter
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.19 | -
 
 This cop enforces the consistent use of action filter methods.
 
@@ -52,9 +52,9 @@ Include | `app/controllers/**/*.rb` | Array
 
 ## Rails/ActiveRecordAliases
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.53 | -
 
 Checks that ActiveRecord aliases are not used. The direct method names
 are more clear and easier to read.
@@ -71,9 +71,9 @@ Book.update!(author: 'Alice')
 
 ## Rails/ActiveSupportAliases
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.48 | -
 
 This cop checks that ActiveSupport aliases to core ruby methods
 are not used.
@@ -96,9 +96,9 @@ are not used.
 
 ## Rails/ApplicationJob
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.49 | -
 
 This cop checks that jobs subclass ApplicationJob with Rails 5.0.
 
@@ -118,9 +118,9 @@ end
 
 ## Rails/ApplicationRecord
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.49 | -
 
 This cop checks that models subclass ApplicationRecord with Rails 5.0.
 
@@ -140,9 +140,9 @@ end
 
 ## Rails/AssertNot
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.56 | -
 
 Use `assert_not` instead of `assert !`.
 
@@ -164,9 +164,9 @@ Include | `**/test/**/*` | Array
 
 ## Rails/BelongsTo
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.62 | -
 
 This cop looks for belongs_to associations where we control whether the
 association is required via the deprecated `required` option instead.
@@ -218,9 +218,9 @@ end
 
 ## Rails/Blank
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.48 | -
 
 This cop checks for code that can be written with simpler conditionals
 using `Object#blank?` defined by Active Support.
@@ -287,9 +287,9 @@ UnlessPresent | `true` | Boolean
 
 ## Rails/BulkChangeTable
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 0.57 | -
 
 This Cop checks whether alter queries are combinable.
 If combinable queries are detected, it suggests to you
@@ -363,9 +363,9 @@ Include | `db/migrate/*.rb` | Array
 
 ## Rails/CreateTableWithTimestamps
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 0.52 | -
 
 This cop checks the migration for which timestamps are not included
 when creating a new table.
@@ -416,9 +416,9 @@ Include | `db/migrate/*.rb` | Array
 
 ## Rails/Date
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 0.30 | 0.33
 
 This cop checks for the correct use of Date methods,
 such as Date.today, Date.current etc.
@@ -475,9 +475,9 @@ EnforcedStyle | `flexible` | `strict`, `flexible`
 
 ## Rails/Delegate
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.21 | 0.50
 
 This cop looks for delegations that could have been created
 automatically with the `delegate` method.
@@ -544,9 +544,9 @@ EnforceForPrefixed | `true` | Boolean
 
 ## Rails/DelegateAllowBlank
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.44 | -
 
 This cop looks for delegations that pass :allow_blank as an option
 instead of :allow_nil. :allow_blank is not a valid option to pass
@@ -564,9 +564,9 @@ delegate :foo, to: :bar, allow_nil: true
 
 ## Rails/DynamicFindBy
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.44 | -
 
 This cop checks dynamic `find_by_*` methods.
 Use `find_by` instead of dynamic method.
@@ -606,9 +606,9 @@ Whitelist | `find_by_sql` | Array
 
 ## Rails/EnumUniqueness
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 0.46 | -
 
 This cop looks for duplicate values in enum declarations.
 
@@ -636,9 +636,9 @@ Include | `app/models/**/*.rb` | Array
 
 ## Rails/EnvironmentComparison
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.52 | -
 
 This cop checks that Rails.env is compared using `.production?`-like
 methods instead of equality against a string or symbol.
@@ -658,9 +658,9 @@ Rails.env.production?
 
 ## Rails/Exit
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 0.41 | -
 
 This cop enforces that `exit` calls are not used within a rails app.
 Valid options are instead to raise an error, break, return, or some
@@ -695,9 +695,9 @@ Exclude | `lib/**/*.rake` | Array
 
 ## Rails/FilePath
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 0.47 | 0.57
 
 This cop is used to identify usages of file path joining process
 to use `Rails.root.join` clause. It is used to add uniformity when
@@ -736,9 +736,9 @@ EnforcedStyle | `arguments` | `slashes`, `arguments`
 
 ## Rails/FindBy
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.30 | -
 
 This cop is used to identify usages of `where.first` and
 change them to use `find_by` instead.
@@ -766,9 +766,9 @@ Include | `app/models/**/*.rb` | Array
 
 ## Rails/FindEach
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.30 | -
 
 This cop is used to identify usages of `all.each` and
 change them to use `all.find_each` instead.
@@ -795,9 +795,9 @@ Include | `app/models/**/*.rb` | Array
 
 ## Rails/HasAndBelongsToMany
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 0.12 | -
 
 This cop checks for the use of the has_and_belongs_to_many macro.
 
@@ -823,9 +823,9 @@ Include | `app/models/**/*.rb` | Array
 
 ## Rails/HasManyOrHasOneDependent
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 0.50 | -
 
 This cop looks for `has_many` or `has_one` associations that don't
 specify a `:dependent` option.
@@ -860,9 +860,9 @@ Include | `app/models/**/*.rb` | Array
 
 ## Rails/HelperInstanceVariable
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 2.0 | -
 
 This cop checks for use of the helper methods which reference
 instance variables.
@@ -896,9 +896,9 @@ Include | `app/helpers/**/*.rb` | Array
 
 ## Rails/HttpPositionalArguments
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.44 | -
 
 This cop is used to identify usages of http methods like `get`, `post`,
 `put`, `patch` without the usage of keyword arguments in your tests and
@@ -925,9 +925,9 @@ Include | `spec/**/*`, `test/**/*` | Array
 
 ## Rails/HttpStatus
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.54 | -
 
 Enforces use of symbolic or numeric value to define HTTP status.
 
@@ -972,9 +972,9 @@ EnforcedStyle | `symbolic` | `numeric`, `symbolic`
 
 ## Rails/IgnoredSkipActionFilterOption
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 0.63 | -
 
 This cop checks that `if` and `only` (or `except`) are not used together
 as options of `skip_*` action filter.
@@ -1024,9 +1024,9 @@ Include | `app/controllers/**/*.rb` | Array
 
 ## Rails/InverseOf
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 0.52 | -
 
 This cop looks for has_(one|many) and belongs_to associations where
 Active Record can't automatically determine the inverse association
@@ -1162,9 +1162,9 @@ Include | `app/models/**/*.rb` | Array
 
 ## Rails/LexicallyScopedActionFilter
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 0.52 | -
 
 This cop checks that methods specified in the filter's `only` or
 `except` options are defined within the same class or module.
@@ -1235,9 +1235,9 @@ Include | `app/controllers/**/*.rb` | Array
 
 ## Rails/LinkToBlank
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.62 | -
 
 This cop checks for calls to `link_to` that contain a
 `target: '_blank'` but no `rel: 'noopener'`. This can be a security
@@ -1260,9 +1260,9 @@ link_to 'Click here', url, target: '_blank', rel: 'noopener'
 
 ## Rails/NotNullColumn
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 0.43 | -
 
 This cop checks for add_column call with NOT NULL constraint
 in migration file.
@@ -1289,9 +1289,9 @@ Include | `db/migrate/*.rb` | Array
 
 ## Rails/Output
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 0.15 | 0.19
 
 This cop checks for the use of output calls like puts and print
 
@@ -1315,9 +1315,9 @@ Include | `app/**/*.rb`, `config/**/*.rb`, `db/**/*.rb`, `lib/**/*.rb` | Array
 
 ## Rails/OutputSafety
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 0.41 | -
 
 This cop checks for the use of output safety calls like `html_safe`,
 `raw`, and `safe_concat`. These methods do not escape content. They
@@ -1384,9 +1384,9 @@ safe_join([user_content, " ", content_tag(:span, user_content)])
 
 ## Rails/PluralizationGrammar
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.35 | -
 
 This cop checks for correct grammar when using ActiveSupport's
 core extensions to the numeric classes.
@@ -1405,9 +1405,9 @@ core extensions to the numeric classes.
 
 ## Rails/Presence
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.52 | -
 
 This cop checks code that can be written more easily using
 `Object#presence` defined by Active Support.
@@ -1449,9 +1449,9 @@ a.presence || b
 
 ## Rails/Present
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.48 | -
 
 This cop checks for code that can be written with simpler conditionals
 using `Object#present?` defined by Active Support.
@@ -1510,9 +1510,9 @@ UnlessBlank | `true` | Boolean
 
 ## Rails/ReadWriteAttribute
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.20 | 0.29
 
 This cop checks for the use of the `read_attribute` or `write_attribute`
 methods and recommends square brackets instead.
@@ -1549,9 +1549,9 @@ Include | `app/models/**/*.rb` | Array
 
 ## Rails/RedundantReceiverInWithOptions
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.52 | -
 
 This cop checks for redundant receiver in `with_options`.
 Receiver is implicit from Rails 4.2 or higher.
@@ -1610,9 +1610,9 @@ end
 
 ## Rails/ReflectionClassName
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 0.64 | -
 
 This cop checks if the value of the option `class_name`, in
 the definition of a reflection is a string.
@@ -1630,9 +1630,9 @@ has_many :accounts, class_name: 'Account'
 
 ## Rails/RefuteMethods
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.56 | -
 
 Use `assert_not` methods instead of `refute` methods.
 
@@ -1658,9 +1658,9 @@ Include | `**/test/**/*` | Array
 
 ## Rails/RelativeDateConstant
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.48 | 0.59
 
 This cop checks whether constant value isn't relative date.
 Because the relative date will be evaluated only once.
@@ -1689,9 +1689,9 @@ AutoCorrect | `false` | Boolean
 
 ## Rails/RequestReferer
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.41 | -
 
 This cop checks for consistent uses of `request.referer` or
 `request.referrer`, depending on the cop's configuration.
@@ -1725,9 +1725,9 @@ EnforcedStyle | `referer` | `referer`, `referrer`
 
 ## Rails/ReversibleMigration
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 0.47 | -
 
 This cop checks whether the change method of the migration file is
 reversible.
@@ -1866,9 +1866,9 @@ Include | `db/migrate/*.rb` | Array
 
 ## Rails/SafeNavigation
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.43 | -
 
 This cop converts usages of `try!` to `&.`. It can also be configured
 to convert `try`. It will convert code to use safe navigation if the
@@ -1917,9 +1917,9 @@ ConvertTry | `false` | Boolean
 
 ## Rails/SaveBang
 
-Enabled by default | Supports autocorrection
---- | ---
-Disabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Disabled | Yes | Yes  | 0.42 | 0.59
 
 This cop identifies possible cases where Active Record save! or related
 should be used instead of save because the model might have failed to
@@ -2032,9 +2032,9 @@ AllowedReceivers | `[]` | Array
 
 ## Rails/ScopeArgs
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 0.19 | -
 
 This cop checks for scope calls where it was passed
 a method (usually a scope) instead of a lambda/proc.
@@ -2057,9 +2057,9 @@ Include | `app/models/**/*.rb` | Array
 
 ## Rails/SkipsModelValidations
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 0.47 | 0.60
 
 This cop checks for the use of methods which skip
 validations which are listed in
@@ -2111,9 +2111,9 @@ Whitelist | `[]` | Array
 
 ## Rails/TimeZone
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 0.30 | 0.33
 
 This cop checks for the use of Time methods without zone.
 
@@ -2176,9 +2176,9 @@ EnforcedStyle | `flexible` | `strict`, `flexible`
 
 ## Rails/UniqBeforePluck
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.40 | 0.47
 
 Prefer the use of uniq (or distinct), before pluck instead of after.
 
@@ -2235,9 +2235,9 @@ AutoCorrect | `false` | Boolean
 
 ## Rails/UnknownEnv
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 0.51 | -
 
 This cop checks that environments called with `Rails.env` predicates
 exist.
@@ -2260,9 +2260,9 @@ Environments | `development`, `test`, `production` | Array
 
 ## Rails/Validation
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.9 | 0.41
 
 This cop checks for the use of old-style attribute validation macros.
 

--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -32,15 +32,29 @@ task generate_cops_documentation: :yard_for_generate_documentation do
     end
   end
 
+  # rubocop:disable Metrics/MethodLength
   def properties(config, cop)
-    header = ['Enabled by default', 'Supports autocorrection']
-    enabled_by_default = config.for_cop(cop).fetch('Enabled')
+    header = [
+      'Enabled by default', 'Safe', 'Supports autocorrection', 'VersionAdded',
+      'VersionChanged'
+    ]
+    config = config.for_cop(cop)
+    safe_auto_correct = config.fetch('SafeAutoCorrect', true)
+    autocorrect = if cop.new.support_autocorrect?
+                    "Yes #{'(Unsafe)' unless safe_auto_correct}"
+                  else
+                    'No'
+                  end
     content = [[
-      enabled_by_default ? 'Enabled' : 'Disabled',
-      cop.new.support_autocorrect? ? 'Yes' : 'No'
+      config.fetch('Enabled') ? 'Enabled' : 'Disabled',
+      config.fetch('Safe', true) ? 'Yes' : 'No',
+      autocorrect,
+      config.fetch('VersionAdded', '-'),
+      config.fetch('VersionChanged', '-')
     ]]
     to_table(header, content) + "\n"
   end
+  # rubocop:enable Metrics/MethodLength
 
   def h2(title)
     content = "\n".dup
@@ -165,7 +179,10 @@ task generate_cops_documentation: :yard_for_generate_documentation do
 
   def print_cop_with_doc(cop, config)
     t = config.for_cop(cop)
-    non_display_keys = %w[Description Enabled StyleGuide Reference]
+    non_display_keys = %w[
+      Description Enabled StyleGuide Reference Safe SafeAutoCorrect VersionAdded
+      VersionChanged
+    ]
     pars = t.reject { |k| non_display_keys.include? k }
     description = 'No documentation'
     examples_object = []


### PR DESCRIPTION
`Rails/HelperInstanceVariable` cop added by rubocop-hq/rubocop-rails#29 isn't backported to RuboCop core.

2.0 has been proposed as the release version of RuboCop Rails, it did so.
https://github.com/toshimaru/rubocop-rails/issues/31#issuecomment-449617550

Cops importing from the RuboCop core has lower than 1.0 so I think it works.

And this PR updates `rake yard_for_generate_documentation` task to add metadata and adds document regenerated by `rake yard_for_generate_documentation`.