### PR TITLE
[Fix #43] Remove `change_column_null` from `BulkChangeTable`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#43](https://github.com/rubocop-hq/rubocop-rails/issues/43): Remove `change_column_null` method from `BulkChangeTable` cop offenses. ([@anthony-robin][])
+
 ## 2.0.1 (2019-06-08)
 
 ### Changes
@@ -18,3 +22,4 @@
 [@koic]: https://github.com/koic
 [@andyw8]: https://github.com/andyw8
 [@buehmann]: https://github.com/buehmann
+[@anthony-robin]: https://github.com/anthony-robin

--- a/lib/rubocop/cop/rails/bulk_change_table.rb
+++ b/lib/rubocop/cop/rails/bulk_change_table.rb
@@ -129,7 +129,6 @@ module RuboCop
 
         POSTGRESQL_COMBINABLE_ALTER_METHODS = %i[
           change_column_default
-          change_column_null
         ].freeze
 
         def on_def(node)

--- a/spec/rubocop/cop/rails/bulk_change_table_spec.rb
+++ b/spec/rubocop/cop/rails/bulk_change_table_spec.rb
@@ -115,8 +115,17 @@ RSpec.describe RuboCop::Cop::Rails::BulkChangeTable, :config do
     it 'registers an offense when including combinable alter methods' do
       expect_offense(<<~RUBY)
         def change
+          change_column_default :users, :name, false
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ You can use `change_table :users, bulk: true` to combine alter queries.
+          change_column_default :users, :address, false
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for `change_column_null`' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def change
           change_column_null :users, :name, false
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ You can use `change_table :users, bulk: true` to combine alter queries.
           change_column_null :users, :address, false
         end
       RUBY
@@ -139,6 +148,13 @@ RSpec.describe RuboCop::Cop::Rails::BulkChangeTable, :config do
     it 'does not register an offense' \
        'when including combinable alter methods' do
       expect_no_offenses(<<~RUBY)
+        def change
+          change_column_default :users, :name, false
+          change_column_default :users, :address, false
+        end
+      RUBY
+
+      expect_no_offenses(<<-RUBY.strip_indent)
         def change
           change_column_null :users, :name, false
           change_column_null :users, :address, false


### PR DESCRIPTION
The `change_column_null` method does not have corresponding method to 
use in the suggested `change_table` version.

We should remove it from the offended methods list.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
