### PR TITLE
Specify `unset_nil: false` to `ConfigLoader.merge_with_default`

### DIFF
--- a/lib/rubocop/rails/inject.rb
+++ b/lib/rubocop/rails/inject.rb
@@ -10,7 +10,7 @@ module RuboCop
         hash = ConfigLoader.send(:load_yaml_configuration, path)
         config = Config.new(hash, path)
         puts "configuration from #{path}" if ConfigLoader.debug?
-        config = ConfigLoader.merge_with_default(config, path)
+        config = ConfigLoader.merge_with_default(config, path, unset_nil: false)
         ConfigLoader.instance_variable_set(:@default_configuration, config)
       end
     end


### PR DESCRIPTION
Follow up https://github.com/rubocop-hq/rubocop/pull/7048.

This PR fixes the following warning.

```console
% cd path/to/rubocop-performance
% bundle exec rake generate_cops_documentation
Files:          54
Modules:         4 (    2 undocumented)
Classes:        55 (    0 undocumented)
Constants:     122 (  122 undocumented)
Attributes:      1 (    0 undocumented)
Methods:       117 (  100 undocumented)
 25.08% documented
Warning: AllCops does not support TargetRailsVersion parameter.

Supported parameters are:

  - RubyInterpreters
  - Include
  - Exclude
  - DefaultFormatter
  - DisplayCopNames
  - DisplayStyleGuide
  - StyleGuideBaseURL
  - ExtraDetails
  - StyleGuideCopsOnly
  - EnabledByDefault
  - DisabledByDefault
  - UseCache
  - MaxFilesInCache
  - CacheRootDirectory
  - AllowSymlinksInCacheRootDirectory
  - TargetRubyVersion

Warning: Rails/BulkChangeTable does not support Database parameter.

Supported parameters are:

  - Enabled
  - SupportedDatabases
  - Include

* generated
  /Users/koic/src/github.com/rubocop-hq/rubocop-rails/manual/cops_rails.md
```

Note: Use of `unset_nil: false` option requires a release higher than RuboCop 0.69.0.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
