### PR TITLE
Update metadata for gemspec

### DIFF
--- a/rubocop-rails.gemspec
+++ b/rubocop-rails.gemspec
@@ -24,10 +24,10 @@ Gem::Specification.new do |s|
   s.summary = 'Automatic Rails code style checking tool.'
 
   s.metadata = {
-    'homepage_uri' => 'https://github.com/rubocop-hq/rubocop-rails/',
+    'homepage_uri' => 'https://docs.rubocop.org/projects/rails',
     'changelog_uri' => 'https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md',
     'source_code_uri' => 'https://github.com/rubocop-hq/rubocop-rails/',
-    'documentation_uri' => 'https://rubocop.readthedocs.io/',
+    'documentation_uri' => 'https://docs.rubocop.org/projects/rails',
     'bug_tracker_uri' => 'https://github.com/rubocop-hq/rubocop-rails/issues'
   }
 


### PR DESCRIPTION
This PR updates metadata for gemspec.

The following URL is published and specified in gemspec.
https://rubocop-rails.readthedocs.io/

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
