### PR TITLE
Update `rubocop` command option in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,10 @@ cops together with the standard cops.
 ### Command line
 
 ```sh
-rubocop --require rubocop-rails
+rubocop --require rubocop-rails --rails
 ```
+
+Note: `--rails` option is required while `rubocop` command supports `--rails` option.
 
 ### Rake task
 


### PR DESCRIPTION
Follow up https://github.com/rubocop-hq/rubocop-rails/issues/55#issuecomment-494617358.

This PR updates `rubocop` command option in README.md.

`rubocop --rails` command option is required while `rubocop` command supports `--rails` option.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
