### PR TITLE
[Fix #56] Add a reference to `rubocop-rails_config` gem in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 A [RuboCop](https://github.com/rubocop-hq/rubocop) extension focused on enforcing Rails best practices and coding conventions.
 
+Note: This repository manages rubocop-rails gem (>= 2.0.0). rubocop-rails gem (<= 1.5.0) has been renamed to [rubocop-rails_config](https://rubygems.org/gems/rubocop-rails_config) gem.
+
 ## Installation
 
 Just install the `rubocop-rails` gem


### PR DESCRIPTION
This PR adds a reference to `rubocop-rails_config` gem in README.md

Fixes #56.
Follow up https://github.com/rubocop-hq/rubocop-rails/pull/57#issuecomment-494311746.
Follow up https://github.com/rubocop-hq/rubocop/issues/5976#issuecomment-495244393.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
