### PR TITLE
Import `target_rails_version` spec from RuboCop core

### DIFF
--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Config do
+  include FileHelper
+
+  subject(:configuration) { described_class.new(hash, loaded_path) }
+
+  let(:loaded_path) { 'example/.rubocop.yml' }
+
+  describe '#target_rails_version' do
+    context 'when TargetRailsVersion is set' do
+      let(:hash) do
+        {
+          'AllCops' => {
+            'TargetRailsVersion' => rails_version
+          }
+        }
+      end
+
+      context 'with patch version' do
+        let(:rails_version) { '5.1.4' }
+        let(:rails_version_to_f) { 5.1 }
+
+        it 'truncates the patch part and converts to a float' do
+          expect(configuration.target_rails_version).to eq rails_version_to_f
+        end
+      end
+
+      context 'correctly' do
+        let(:rails_version) { 4.0 }
+
+        it 'uses TargetRailsVersion' do
+          expect(configuration.target_rails_version).to eq rails_version
+        end
+      end
+    end
+
+    context 'when TargetRailsVersion is not set', :isolated_environment do
+      let(:hash) do
+        {
+          'AllCops' => {}
+        }
+      end
+
+      context 'and lock files do not exist' do
+        it 'uses the default rails version' do
+          default = RuboCop::Config::DEFAULT_RAILS_VERSION
+          expect(configuration.target_rails_version).to eq default
+        end
+      end
+
+      ['Gemfile.lock', 'gems.locked'].each do |file_name|
+        context "and #{file_name} exists" do
+          let(:base_path) { configuration.base_dir_for_path_parameters }
+          let(:lock_file_path) { File.join(base_path, file_name) }
+
+          it "uses the single digit Rails version in #{file_name}" do
+            content =
+              <<-HEREDOC
+                GEM
+                  remote: https://rubygems.org/
+                  specs:
+                    actionmailer (4.1.0)
+                    actionpack (= 4.1.0)
+                    actionview (= 4.1.0)
+                    mail (~> 2.5.4)
+                  rails (4.1.0)
+                    actionmailer (= 4.1.0)
+                    actionpack (= 4.1.0)
+                    actionview (= 4.1.0)
+                    activemodel (= 4.1.0)
+                    activerecord (= 4.1.0)
+                    activesupport (= 4.1.0)
+                    bundler (>= 1.3.0, < 2.0)
+                    railties (= 4.1.0)
+                    sprockets-rails (~> 2.0)
+
+                PLATFORMS
+                  ruby
+
+                DEPENDENCIES
+                  rails (= 4.1.0)
+
+                BUNDLED WITH
+                  1.16.1
+              HEREDOC
+            create_file(lock_file_path, content)
+            expect(configuration.target_rails_version).to eq 4.1
+          end
+
+          it "uses the multi digit Rails version in #{file_name}" do
+            content =
+              <<-HEREDOC
+                GEM
+                  remote: https://rubygems.org/
+                  specs:
+                    actionmailer (4.1.0)
+                    actionpack (= 4.1.0)
+                    actionview (= 4.1.0)
+                    mail (~> 2.5.4)
+                  rails (400.33.22)
+                    actionmailer (= 4.1.0)
+                    actionpack (= 4.1.0)
+                    actionview (= 4.1.0)
+                    activemodel (= 4.1.0)
+                    activerecord (= 4.1.0)
+                    activesupport (= 4.1.0)
+                    bundler (>= 1.3.0, < 2.0)
+                    railties (= 4.1.0)
+                    sprockets-rails (~> 2.0)
+
+                PLATFORMS
+                  ruby
+
+                DEPENDENCIES
+                  rails (= 900.88.77)
+
+                BUNDLED WITH
+                  1.16.1
+              HEREDOC
+            create_file(lock_file_path, content)
+            expect(configuration.target_rails_version).to eq 400.33
+          end
+
+          it "does not use the DEPENDENCIES Rails version in #{file_name}" do
+            content =
+              <<-HEREDOC
+                GEM
+                  remote: https://rubygems.org/
+                  specs:
+                    actionmailer (4.1.0)
+                    actionpack (= 4.1.0)
+                    actionview (= 4.1.0)
+                    mail (~> 2.5.4)
+
+                PLATFORMS
+                  ruby
+
+                DEPENDENCIES
+                  rails (= 900.88.77)
+
+                BUNDLED WITH
+                  1.16.1
+              HEREDOC
+            create_file(lock_file_path, content)
+            expect(configuration.target_rails_version).not_to eq 900.88
+          end
+
+          it "uses the default Rails when Rails is not in #{file_name}" do
+            content =
+              <<-HEREDOC
+                GEM
+                  remote: https://rubygems.org/
+                  specs:
+                    addressable (2.5.2)
+                      public_suffix (>= 2.0.2, < 4.0)
+                    ast (2.4.0)
+                    bump (0.5.4)
+
+                PLATFORMS
+                  ruby
+
+                DEPENDENCIES
+                  bump
+                  bundler (~> 1.3)
+
+                BUNDLED WITH
+                  1.16.1
+              HEREDOC
+            create_file(lock_file_path, content)
+            default = RuboCop::Config::DEFAULT_RAILS_VERSION
+            expect(configuration.target_rails_version).to eq default
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 require 'rubocop-rails'
 require 'rubocop/rspec/support'
+require_relative 'support/file_helper'
+require_relative 'support/shared_contexts'
 
 if ENV['COVERAGE'] == 'true'
   require 'simplecov'

--- a/spec/support/file_helper.rb
+++ b/spec/support/file_helper.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+
+module FileHelper
+  def create_file(file_path, content)
+    file_path = File.expand_path(file_path)
+
+    dir_path = File.dirname(file_path)
+    FileUtils.makedirs dir_path unless File.exist?(dir_path)
+
+    File.open(file_path, 'w') do |file|
+      case content
+      when String
+        file.puts content
+      when Array
+        file.puts content.join("\n")
+      end
+    end
+  end
+
+  def create_empty_file(file_path)
+    create_file(file_path, '')
+  end
+end

--- a/spec/support/shared_contexts.rb
+++ b/spec/support/shared_contexts.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'with Rails 3', :rails3 do
+  let(:rails_version) { 3.0 }
+end
+
+RSpec.shared_context 'with Rails 4', :rails4 do
+  let(:rails_version) { 4.0 }
+end
+
+RSpec.shared_context 'with Rails 5', :rails5 do
+  let(:rails_version) { 5.0 }
+end


### PR DESCRIPTION
This PR imports `target_rails_version` spec from RuboCop core.

The following warning will be resolved with rubocop-hq/rubocop#7095.

```console
% bundle exec rake

(snip)

WARNING: Shared example group 'with Rails 3' has been previously defined
at:
  /Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/rspec/shared_contexts.rb:85
...and you are now defining it at:
  /Users/koic/src/github.com/rubocop-hq/rubocop-rails/spec/support/shared_contexts.rb:3
The new definition will overwrite the original one.
WARNING: Shared example group 'with Rails 4' has been previously defined
at:
  /Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/rspec/shared_contexts.rb:89
...and you are now defining it at:
  /Users/koic/src/github.com/rubocop-hq/rubocop-rails/spec/support/shared_contexts.rb:7
The new definition will overwrite the original one.
WARNING: Shared example group 'with Rails 5' has been previously defined
at:
  /Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/rspec/shared_contexts.rb:93
...and you are now defining it at:
  /Users/koic/src/github.com/rubocop-hq/rubocop-rails/spec/support/shared_contexts.rb:11
The new definition will overwrite the original one.
/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.0/lib/rspec/core/memoized_helpers.rb:291:
warning: method redefined; discarding old rails_version
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/rspec/shared_contexts.rb:86:
warning: previous definition of rails_version was here
/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.0/lib/rspec/core/memoized_helpers.rb:298:
warning: method redefined; discarding old rails_version
/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.0/lib/rspec/core/memoized_helpers.rb:298:
warning: previous definition of rails_version was here
/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.0/lib/rspec/core/memoized_helpers.rb:291:
warning: method redefined; discarding old rails_version
/Users/koic/src/github.com/rubocop-hq/rubocop/lib/rubocop/rspec/shared_contexts.rb:90:
warning: previous definition of rails_version was here
/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.0/lib/rspec/core/memoized_helpers.rb:298:
warning: method redefined; discarding old rails_version
/Users/koic/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-core-3.8.0/lib/rspec/core/memoized_helpers.rb:298:
warning: previous definition of rails_version was Here
```

spec/support/file_helper.rb was imported from the following.
https://github.com/rubocop-hq/rubocop/blob/v0.71.0/spec/support/file_helper.rb

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
