### PR TITLE
Add a way to specify multiple extensions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ Put this into your `.rubocop.yml`.
 require: rubocop-rails
 ```
 
+Alternatively, use the following array notation when specifying multiple extensions.
+
+```yaml
+require:
+  - rubocop-other-extension
+  - rubocop-rails
+```
+
 Now you can run `rubocop` and it will automatically load the RuboCop Rails
 cops together with the standard cops.
 


### PR DESCRIPTION
Follow up https://github.com/rubocop-hq/rubocop/issues/7104 and https://github.com/rubocop-hq/rubocop-jp/issues/53 (JA) .

This PR adds a way to specify multiple extensions to README.md.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
