### PR TITLE
Relax rack dependency for Rails 4

### DIFF
--- a/rubocop-rails.gemspec
+++ b/rubocop-rails.gemspec
@@ -31,7 +31,9 @@ Gem::Specification.new do |s|
     'bug_tracker_uri' => 'https://github.com/rubocop-hq/rubocop-rails/issues'
   }
 
-  s.add_runtime_dependency 'rack', '>= 2.0'
+  # Rack::Utils::SYMBOL_TO_STATUS_CODE, which is used by HttpStatus cop, was
+  # introduced in rack 1.1
+  s.add_runtime_dependency 'rack', '>= 1.1'
   s.add_runtime_dependency 'rubocop', '>= 0.70.0'
 end
 # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
This is related to #37. `rack` was recently made a runtime dependency: #36:

```ruby
s.add_runtime_dependency 'rack', '>= 2.0'
```

Now this conflicts with an older Rails 4 app of ours which requires an older rack version:
```
    actionpack (4.2.11.1)
      rack (~> 1.6)
```

The only rack interface that is used seems to be `::Rack::Utils::SYMBOL_TO_STATUS_CODE` which first appeared in rack 1.1: https://github.com/rack/rack/commit/5c4bd17d791d97310667acf6b458456aa1f8af0d

Is there a particular reason why you enforce rack >= 2.0 or could we relax that dependency?