### PR TITLE
[Fix #67] TimeZone: Always autocorrect `DateTime` => `Time`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#67](https://github.com/rubocop-hq/rubocop-rails/issues/67): [Fix #67] TimeZone: Always autocorrect `DateTime` => `Time` ([@vfonic][])
+
 ## 2.0.0 (2019-05-22)
 
 ### New features

--- a/lib/rubocop/cop/rails/time_zone.rb
+++ b/lib/rubocop/cop/rails/time_zone.rb
@@ -82,9 +82,7 @@ module RuboCop
               corrector.replace(node.loc.selector, 'now')
             end
             # prefer `Time` over `DateTime` class
-            if strict?
-              corrector.replace(node.children.first.source_range, 'Time')
-            end
+            corrector.replace(node.children.first.source_range, 'Time')
             remove_redundant_in_time_zone(corrector, node)
           end
         end

--- a/spec/rubocop/cop/rails/time_zone_spec.rb
+++ b/spec/rubocop/cop/rails/time_zone_spec.rb
@@ -64,10 +64,6 @@ RSpec.describe RuboCop::Cop::Rails::TimeZone, :config do
       end
 
       context 'autocorrect' do
-        let(:cop_config) do
-          { 'AutoCorrect' => 'true', 'EnforcedStyle' => 'strict' }
-        end
-
         it 'autocorrects correctly' do
           source = "#{klass}.now.in_time_zone"
           new_source = autocorrect_source(source)
@@ -275,10 +271,6 @@ RSpec.describe RuboCop::Cop::Rails::TimeZone, :config do
         end
 
         context 'autocorrect' do
-          let(:cop_config) do
-            { 'AutoCorrect' => 'true', 'EnforcedStyle' => 'flexible' }
-          end
-
           it 'corrects the error' do
             source = <<~RUBY
               #{klass}.#{a_method}
@@ -286,7 +278,7 @@ RSpec.describe RuboCop::Cop::Rails::TimeZone, :config do
             new_source = autocorrect_source(source)
             unless a_method == :current
               expect(new_source).to eq(<<~RUBY)
-                #{klass}.zone.#{a_method}
+                Time.zone.#{a_method}
               RUBY
             end
           end


### PR DESCRIPTION
This removes potential (and actual) bugs due to some methods not being present on `DateTime` class that are present on `Time` class.
If we always autocorrect to `Time`, we ensure the most appropriate correction.

https://github.com/rubocop-hq/rubocop-rails/issues/67
https://github.com/rubocop-hq/rubocop/pull/6930#issuecomment-482940444

Sidenote: I believe a lot of problems here also comes from the tests that are a little bit hard to follow. The tests seem to have been written for code efficiency / lower line numbers. But they make it hard to understand which test refers to which of the two classes (`Time` or `DateTime`) and what exactly is being tested:

Why are "accepted methods" registering offenses:
```ruby
      described_class::ACCEPTED_METHODS.each do |a_method|
        it "registers an offense #{klass}.now.#{a_method}" do
          inspect_source("#{klass}.now.#{a_method}")
          expect(cop.offenses.size).to eq(1)
          expect(cop.offenses.first.message).to include('`Time.zone.now`')
        end
      end
```

Etc.
If we decide to keep only one mode (as opposed to `['flexible', 'strict']`, I believe the refactoring should start from the tests.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/