### PR TITLE
RuboCop Rails supports Rails 4 or higher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#43](https://github.com/rubocop-hq/rubocop-rails/issues/43): Remove `change_column_null` method from `BulkChangeTable` cop offenses. ([@anthony-robin][])
 
+### Changes
+
+* [#74](https://github.com/rubocop-hq/rubocop-rails/pull/74): Drop Rails 3 support. ([@koic][])
+
 ## 2.0.1 (2019-06-08)
 
 ### Changes

--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ Rails/FindBy:
     - lib/example.rb
 ```
 
+## Compatibility
+
+Rails cops support the following versions:
+
+- Rails 4.0+
+
 ## Contributing
 
 Checkout the [contribution guidelines](CONTRIBUTING.md).

--- a/lib/rubocop/cop/rails/action_filter.rb
+++ b/lib/rubocop/cop/rails/action_filter.rb
@@ -33,7 +33,6 @@ module RuboCop
       #   append_around_filter :do_stuff
       #   skip_after_filter :do_stuff
       class ActionFilter < Cop
-        extend TargetRailsVersion
         include ConfigurableEnforcedStyle
 
         MSG = 'Prefer `%<prefer>s` over `%<current>s`.'
@@ -69,8 +68,6 @@ module RuboCop
           skip_before_action
           skip_action_callback
         ].freeze
-
-        minimum_target_rails_version 4.0
 
         def on_block(node)
           check_method_node(node.send_node)

--- a/lib/rubocop/cop/rails/reversible_migration.rb
+++ b/lib/rubocop/cop/rails/reversible_migration.rb
@@ -231,12 +231,7 @@ module RuboCop
 
         def check_change_table_node(node, block)
           change_table_call(node) do |arg|
-            if target_rails_version < 4.0
-              add_offense(
-                node,
-                message: format(MSG, action: 'change_table')
-              )
-            elsif block.send_type?
+            if block.send_type?
               check_change_table_offense(arg, block)
             else
               block.each_child_node(:send) do |child_node|

--- a/spec/rubocop/cop/rails/action_filter_spec.rb
+++ b/spec/rubocop/cop/rails/action_filter_spec.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Rails::ActionFilter, :config do
+  subject(:cop) { described_class.new(config) }
+
+  let(:cop_config) { { 'Include' => nil } }
+
   describe '::FILTER_METHODS' do
     it 'contains all of the filter methods' do
       expect(described_class::FILTER_METHODS).to eq(%i[
@@ -41,121 +45,63 @@ RSpec.describe RuboCop::Cop::Rails::ActionFilter, :config do
     end
   end
 
-  context 'Rails <= 4.0', :rails3 do
-    subject(:cop) { described_class.new(config) }
+  context 'when style is action' do
+    before do
+      cop_config['EnforcedStyle'] = 'action'
+    end
 
-    let(:cop_config) { { 'Include' => nil } }
-
-    context 'when using action methods' do
-      described_class::FILTER_METHODS.each do |method|
-        it "does not register an offense for #{method}" do
-          expect_no_offenses("#{method} :name")
-        end
-
-        it "does not register an offense for #{method} with block" do
-          expect_no_offenses("#{method} { |controller| something }")
-        end
+    described_class::FILTER_METHODS.each do |method|
+      it "registers an offense for #{method}" do
+        inspect_source_file("#{method} :name")
+        expect(cop.offenses.size).to eq(1)
       end
 
-      described_class::ACTION_METHODS.each do |method|
-        it "accepts #{method}" do
-          expect_no_offenses("#{method} :something")
-        end
-      end
-
-      it 'does not auto-correct to preferred method' do
-        new_source = autocorrect_source_file('before_filter :test')
-        expect(new_source).to eq('before_filter :test')
+      it "registers an offense for #{method} with block" do
+        inspect_source_file("#{method} { |controller| something }")
+        expect(cop.offenses.size).to eq(1)
       end
     end
 
-    context 'when using filter methods' do
-      described_class::ACTION_METHODS.each do |method|
-        it "does not register an offense for #{method}" do
-          expect_no_offenses("#{method} :name")
-        end
-
-        it "does not register an offense for #{method} with block" do
-          expect_no_offenses("#{method} { |controller| something }")
-        end
+    described_class::ACTION_METHODS.each do |method|
+      it "accepts #{method}" do
+        inspect_source_file("#{method} :something")
+        expect(cop.offenses.empty?).to be(true)
       end
+    end
 
-      described_class::FILTER_METHODS.each do |method|
-        it "accepts #{method}" do
-          expect_no_offenses("#{method} :something")
-        end
-      end
-
-      it 'does not auto-correct to preferred method' do
-        new_source = autocorrect_source_file('before_action :test')
-        expect(new_source).to eq('before_action :test')
-      end
+    it 'auto-corrects to preferred method' do
+      new_source = autocorrect_source_file('before_filter :test')
+      expect(new_source).to eq('before_action :test')
     end
   end
 
-  context 'Rails >= 4.0', :rails4 do
-    subject(:cop) { described_class.new(config) }
+  context 'when style is filter' do
+    before do
+      cop_config['EnforcedStyle'] = 'filter'
+    end
 
-    let(:cop_config) { { 'Include' => nil } }
-
-    context 'when style is action' do
-      before do
-        cop_config['EnforcedStyle'] = 'action'
+    described_class::ACTION_METHODS.each do |method|
+      it "registers an offense for #{method}" do
+        inspect_source_file("#{method} :name")
+        expect(cop.offenses.size).to eq(1)
       end
 
-      described_class::FILTER_METHODS.each do |method|
-        it "registers an offense for #{method}" do
-          inspect_source_file("#{method} :name")
-          expect(cop.offenses.size).to eq(1)
-        end
-
-        it "registers an offense for #{method} with block" do
-          inspect_source_file("#{method} { |controller| something }")
-          expect(cop.offenses.size).to eq(1)
-        end
-      end
-
-      described_class::ACTION_METHODS.each do |method|
-        it "accepts #{method}" do
-          inspect_source_file("#{method} :something")
-          expect(cop.offenses.empty?).to be(true)
-        end
-      end
-
-      it 'auto-corrects to preferred method' do
-        new_source = autocorrect_source_file('before_filter :test')
-        expect(new_source).to eq('before_action :test')
+      it "registers an offense for #{method} with block" do
+        inspect_source_file("#{method} { |controller| something }")
+        expect(cop.offenses.size).to eq(1)
       end
     end
 
-    context 'when style is filter' do
-      before do
-        cop_config['EnforcedStyle'] = 'filter'
+    described_class::FILTER_METHODS.each do |method|
+      it "accepts #{method}" do
+        inspect_source_file("#{method} :something")
+        expect(cop.offenses.empty?).to be(true)
       end
+    end
 
-      described_class::ACTION_METHODS.each do |method|
-        it "registers an offense for #{method}" do
-          inspect_source_file("#{method} :name")
-          expect(cop.offenses.size).to eq(1)
-        end
-
-        it "registers an offense for #{method} with block" do
-          inspect_source_file("#{method} { |controller| something }")
-          expect(cop.offenses.size).to eq(1)
-        end
-      end
-
-      described_class::FILTER_METHODS.each do |method|
-        it "accepts #{method}" do
-          inspect_source_file("#{method} :something")
-          expect(cop.offenses.empty?).to be(true)
-        end
-      end
-
-      it 'auto-corrects to preferred method' do
-        new_source = autocorrect_source_file('before_action :test')
-        expect(new_source).to eq('before_filter :test')
-      end
+    it 'auto-corrects to preferred method' do
+      new_source = autocorrect_source_file('before_action :test')
+      expect(new_source).to eq('before_filter :test')
     end
   end
 end

--- a/spec/rubocop/cop/rails/reversible_migration_spec.rb
+++ b/spec/rubocop/cop/rails/reversible_migration_spec.rb
@@ -151,60 +151,30 @@ RSpec.describe RuboCop::Cop::Rails::ReversibleMigration, :config do
   end
 
   context 'change_table' do
-    context 'Rails < 4.0', :rails3 do
-      it_behaves_like 'offense', 'change_table', <<-RUBY
-        change_table :users do |t|
-          t.column :name, :string
-          t.text :description
-          t.boolean :authorized
-        end
-      RUBY
+    it_behaves_like 'accepts', 'change_table(with reversible calls)', <<-RUBY
+      change_table :users do |t|
+        t.column :name, :string
+        t.text :description
+        t.boolean :authorized
+      end
+    RUBY
 
-      it_behaves_like 'offense', 'change_table', <<-RUBY
-        change_table :users do |t|
-          t.change :description, :text
-        end
-      RUBY
+    it_behaves_like 'offense', 'change_table(with change)', <<-RUBY
+      change_table :users do |t|
+        t.change :description, :text
+      end
+    RUBY
 
-      it_behaves_like 'offense', 'change_table', <<-RUBY
-        change_table :users do |t|
-          t.change_default :authorized, 1
-        end
-      RUBY
+    it_behaves_like 'offense', 'change_table(with change_default)', <<-RUBY
+      change_table :users do |t|
+        t.change_default :authorized, 1
+      end
+    RUBY
 
-      it_behaves_like 'offense', 'change_table', <<-RUBY
-        change_table :users do |t|
-          t.remove :qualification
-        end
-      RUBY
-    end
-
-    context 'Rails >= 4.0', :rails4 do
-      it_behaves_like 'accepts', 'change_table(with reversible calls)', <<-RUBY
-        change_table :users do |t|
-          t.column :name, :string
-          t.text :description
-          t.boolean :authorized
-        end
-      RUBY
-
-      it_behaves_like 'offense', 'change_table(with change)', <<-RUBY
-        change_table :users do |t|
-          t.change :description, :text
-        end
-      RUBY
-
-      it_behaves_like 'offense', 'change_table(with change_default)', <<-RUBY
-        change_table :users do |t|
-          t.change_default :authorized, 1
-        end
-      RUBY
-
-      it_behaves_like 'offense', 'change_table(with remove)', <<-RUBY
-        change_table :users do |t|
-          t.remove :qualification
-        end
-      RUBY
-    end
+    it_behaves_like 'offense', 'change_table(with remove)', <<-RUBY
+      change_table :users do |t|
+        t.remove :qualification
+      end
+    RUBY
   end
 end

--- a/spec/support/shared_contexts.rb
+++ b/spec/support/shared_contexts.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-RSpec.shared_context 'with Rails 3', :rails3 do
-  let(:rails_version) { 3.0 }
-end
-
 RSpec.shared_context 'with Rails 4', :rails4 do
   let(:rails_version) { 4.0 }
 end


### PR DESCRIPTION
This PR drops Rails 3 support.

RuboCop core was supported Rails 4+.
https://github.com/rubocop-hq/rubocop/tree/v0.71.0#compatibility

> The Rails cops support the following versions:
>
> - Rails 4.0+

It conforms to the expected behavior of RuboCop core originally.

And Rails is maintained at 4.2.Z or higher.

> 4 Severe Security Issues
> For severe security issues all releases in the current major series, and
> also the last major release series will receive patches and new
> versions. The classification of the security issue is judged by the core
> team.
>
> Currently included series: 5.2.Z, 5.1.Z, 5.0.Z, 4.2.Z.

https://guides.rubyonrails.org/maintenance_policy.html

The following is the RuboCop Rails and Rails 4 use case.
https://github.com/rubocop-hq/rubocop-rails/pull/68

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
