### PR TITLE
Fix a build error

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,9 @@ Naming/PredicateName:
     - def_node_matcher
     - def_node_search
 
+Rails:
+  Enabled: false
+
 Style/FormatStringToken:
   # Because we parse a lot of source codes from strings. Percent arrays
   # look like unannotated format string tokens to this cop.

--- a/Rakefile
+++ b/Rakefile
@@ -13,6 +13,7 @@ rescue Bundler::BundlerError => e
   exit e.status_code
 end
 
+require 'rubocop/rake_task'
 require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec) do |spec|
@@ -25,16 +26,19 @@ task :coverage do
   Rake::Task['spec'].execute
 end
 
-desc 'Run RuboCop over this gem'
-task :internal_investigation do
-  sh('bundle exec rubocop')
+desc 'Run RuboCop over itself'
+RuboCop::RakeTask.new(:internal_investigation).tap do |task|
+  if RUBY_ENGINE == 'ruby' &&
+     RbConfig::CONFIG['host_os'] !~ /mswin|msys|mingw|cygwin|bccwin|wince|emc/
+    task.options = %w[--parallel]
+  end
 end
 
 task default: %i[
-  internal_investigation
   documentation_syntax_check
   generate_cops_documentation
   spec
+  internal_investigation
 ]
 
 desc 'Generate a new cop template'


### PR DESCRIPTION
This PR fixes the following build error when using rubocophq/circleci-ruby-snapshot:latest image.

```console
$ docker run --rm -it rubocophq/circleci-ruby-snapshot:latest
# In docker
$ cd
$ git clone https://github.com/rubocop-hq/rubocop-rails
$ cd rubocop-rails
$ bundle install
$ bundle exec rake
bundle exec rubocop
Traceback (most recent call last):
        1: from /usr/local/bin/bundle:23:in `<main>'
/usr/local/bin/bundle:23:in `load': cannot load such file --
/usr/local/lib/bin/bundle (LoadError)
rake aborted!
Command failed with status (1): [bundle exec rubocop...]
/home/circleci/rubocop-rails/Rakefile:30:in `block in <top (required)>'
/usr/local/bundle/gems/rake-12.3.2/exe/rake:27:in `<top (required)>'
/usr/local/bin/bundle:23:in `load'
/usr/local/bin/bundle:23:in `<main>'
Tasks: TOP => default => internal_investigation
(See full trace by running task with --trace)
```

https://circleci.com/gh/rubocop-hq/rubocop-rails/804

This change is based on RuboCop core's Rakefile.
https://github.com/rubocop-hq/rubocop/blob/v0.71.0/Rakefile#L27-L33

And this PR disables Rails cops because this rubocop-hq/rubocop-rails repository is not a Rails application.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
