### PR TITLE
Remove outdated doc for `Rails/ActionFilter`

### DIFF
--- a/lib/rubocop/cop/rails/action_filter.rb
+++ b/lib/rubocop/cop/rails/action_filter.rb
@@ -8,9 +8,6 @@ module RuboCop
       # The cop is configurable and can enforce the use of the older
       # something_filter methods or the newer something_action methods.
       #
-      # If the TargetRailsVersion is set to less than 4.0, the cop will enforce
-      # the use of filter methods.
-      #
       # @example EnforcedStyle: action (default)
       #   # bad
       #   after_filter :do_stuff

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -11,9 +11,6 @@ This cop enforces the consistent use of action filter methods.
 The cop is configurable and can enforce the use of the older
 something_filter methods or the newer something_action methods.
 
-If the TargetRailsVersion is set to less than 4.0, the cop will enforce
-the use of filter methods.
-
 ### Examples
 
 #### EnforcedStyle: action (default)


### PR DESCRIPTION
Follow up #74.

RuboCop Rails doesn't support Rails 3 or lower.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
