### PR TITLE
[Fix #79] Rubocop::Cop::Rails constant removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#43](https://github.com/rubocop-hq/rubocop-rails/issues/43): Remove `change_column_null` method from `BulkChangeTable` cop offenses. ([@anthony-robin][])
+* [#79](https://github.com/rubocop-hq/rubocop-rails/issues/79): Fix `RuboCop::Cop::Rails not defined (NameError)`. ([@rmm5t][])
 
 ### Changes
 
@@ -27,3 +28,4 @@
 [@andyw8]: https://github.com/andyw8
 [@buehmann]: https://github.com/buehmann
 [@anthony-robin]: https://github.com/anthony-robin
+[@rmm5t]: https://github.com/rmm5t

--- a/lib/rubocop/cop/rails_cops.rb
+++ b/lib/rubocop/cop/rails_cops.rb
@@ -4,7 +4,7 @@ module RuboCop
   # RuboCop included the Rails cops directly before version 1.0.0.
   # We can remove them to avoid warnings about redefining constants.
   module Cop
-    remove_const('Rails') if const_defined?('Rails')
+    remove_const('Rails') if const_defined?('Rails', false)
   end
 end
 


### PR DESCRIPTION
Avoids the following error in conjunction with rubocop v0.72:

`RuboCop::Cop::Rails not defined (NameError)`

Fixes #79 

Before, it attempted to remove the constant whether `Rubocop::Cop::Rails` was defined or if `::Rails` was defined. Turning off the `inherit` flag while checking `const_defined?` remedies this.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests. **(N/A)**
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
