### PR TITLE
Remove unnecessary code to suppress warnings

### DIFF
--- a/lib/rubocop/cop/rails_cops.rb
+++ b/lib/rubocop/cop/rails_cops.rb
@@ -1,13 +1,5 @@
 # frozen_string_literal: true
 
-module RuboCop
-  # RuboCop included the Rails cops directly before version 1.0.0.
-  # We can remove them to avoid warnings about redefining constants.
-  module Cop
-    remove_const('Rails') if const_defined?('Rails', false)
-  end
-end
-
 require_relative 'mixin/target_rails_version'
 
 require_relative 'rails/action_filter'


### PR DESCRIPTION
Follow up https://github.com/rubocop-hq/rubocop-rails/pull/80.
(Thank you for this PR that solved issue #79 early.)

Rails cops has been removed from RuboCop 0.72.
https://github.com/rubocop-hq/rubocop/releases/tag/v0.72.0

As a result of verification, the code to guard a warning is not necessary already.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
