### PR TITLE
[Fix #67] Fix an incorrect auto-correct for `Rails/TimeZone`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#67](https://github.com/rubocop-hq/rubocop-rails/issues/67): Fix an incorrect auto-correct for `Rails/TimeZone` when using `DateTime`. ([@koic][])
+
 ## 2.1.0 (2019-06-26)
 
 ### Bug fixes

--- a/lib/rubocop/cop/rails/time_zone.rb
+++ b/lib/rubocop/cop/rails/time_zone.rb
@@ -55,8 +55,6 @@ module RuboCop
         MSG_LOCALTIME = 'Do not use `Time.localtime` without ' \
                         'offset or zone.'
 
-        TIMECLASSES = %i[Time DateTime].freeze
-
         GOOD_METHODS = %i[zone zone_default find_zone find_zone!].freeze
 
         DANGEROUS_METHODS = %i[now local new parse at current].freeze
@@ -67,10 +65,10 @@ module RuboCop
         def on_const(node)
           mod, klass = *node
           # we should only check core classes
-          # (`DateTime`, `Time`, `::DateTime` or `::Time`)
+          # (`Time` or `::Time`)
           return unless (mod.nil? || mod.cbase_type?) && method_send?(node)
 
-          check_time_node(klass, node.parent) if TIMECLASSES.include?(klass)
+          check_time_node(klass, node.parent) if klass == :Time
         end
 
         def autocorrect(node)
@@ -153,7 +151,7 @@ module RuboCop
           if (receiver.is_a? RuboCop::AST::Node) && !receiver.cbase_type?
             method_from_time_class?(receiver)
           else
-            TIMECLASSES.include?(method_name)
+            method_name == :Time
           end
         end
 


### PR DESCRIPTION
Fixes #67.
Closes #71.

This PR fixes an incorrect auto-correct for `Rails/TimeZone` when using `DateTime`.

```diff
- DateTime.new
+ DateTime.zone.new
```

```ruby
DateTime.zone.new # NoMethodError: undefined method `zone' for
DateTime:Class
```

This PR changes to ignore `DateTime` with the following as background.

`DateTime` is not mentioned in The Rails Style Guide and `Rails/TimeZone` cop's examples.

- https://rails.rubystyle.guide/#time-now
- https://docs.rubocop.org/projects/rails/en/stable/cops_rails/#railstimezone

Recently, #81 and #82 have been feedback.
I think breaking by auto-correction should be fixed with the highest priority in this case.

Also, `DateTime` and `Time` are not replaced from `DateTime` to `Time` by auto-correct because they are different objects.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
