### PR TITLE
[#86] Fix an incorrect auto-correct for `Rails/TimeZone`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* [#86](https://github.com/rubocop-hq/rubocop-rails/issues/86): Fix an incorrect auto-correct for `Rails/TimeZone` when using `Time.new`. ([@koic][])
+
 ## 2.2.0 (2019-07-07)
 
 ### Bug fixes


### PR DESCRIPTION
Fixes #86.

This PR fixes an incorrect auto-correct for `Rails/TimeZone` when using `Time.new`.

### Before

```diff
- Time.new
+ Time.zone.new  #=> NoMethodError: undefined method `new'

- Time.new(2019, 7, 7, 10, 15, 25)
+ Time.zone.new(2019, 7, 7, 10, 15, 25) #=> NoMethodError: undefined method `new'
```

### After

```diff
- Time.new
+ Time.zone.now

- Time.new(2019, 7, 7, 10, 15, 25)
+ Time.zone.local(2019, 7, 7, 10, 15, 25)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
