### PR TITLE
Fix false negatives for Rails/EnumHash cop

### DIFF
--- a/spec/rubocop/cop/rails/enum_hash_spec.rb
+++ b/spec/rubocop/cop/rails/enum_hash_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe RuboCop::Cop::Rails::EnumHash do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           enum status: %i[active archived]
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+                       ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
         RUBY
       end
     end
@@ -19,7 +19,7 @@ RSpec.describe RuboCop::Cop::Rails::EnumHash do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           enum status: %w[active archived]
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+                       ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
         RUBY
       end
     end
@@ -28,7 +28,7 @@ RSpec.describe RuboCop::Cop::Rails::EnumHash do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           enum status: %i(active archived)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+                       ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
         RUBY
       end
     end
@@ -37,7 +37,7 @@ RSpec.describe RuboCop::Cop::Rails::EnumHash do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           enum status: %w(active archived)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+                       ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
         RUBY
       end
     end
@@ -46,7 +46,36 @@ RSpec.describe RuboCop::Cop::Rails::EnumHash do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           enum status: [:active, :archived]
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+                       ^^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+        RUBY
+      end
+    end
+
+    context 'when the enum name is a string' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          enum "status" => %i[active archived]
+                           ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+        RUBY
+      end
+    end
+
+    context 'when the enum name is not a literal' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          enum KEY => %i[active archived]
+                      ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `KEY` enum declaration. Use hash syntax instead.
+        RUBY
+      end
+    end
+
+    context 'with multiple enum definition for a `enum` method call' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          enum status: %i[active archived],
+                       ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+               role: %i[owner member guest]
+                     ^^^^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `role` enum declaration. Use hash syntax instead.
         RUBY
       end
     end


### PR DESCRIPTION
Rails/EnumHash cop has been introduced in #94. Thanks!


But the cop has two false negatives. This pull request will fix them.


# with non-symbol key


This cop does not detect `enum` call with non-symbol key. For example:

```ruby
KEY = :status
enum KEY => %i[active archived]
```


# with multiple keys

`enum` allows defining multiple enums in one `enum` method call.

```ruby
enum status: %i[active archived],
     role: %i[owner member]
```

But the cop is not aware of the code.



# Note

The cop has not been released yet, so I did not write any changelog for the pull request.

I wait merging #95 to review this pull request. Thanks.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
