### PR TITLE
Mark ActiveRecord/Aliases as unsafe autocorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 * [#53](https://github.com/rubocop-hq/rubocop-rails/issues/53): Fix a false positive for `Rails/SaveBang` when implicitly return using finder method and creation method connected by `||`. ([@koic][])
 
+### Changes
+
+* [#98](https://github.com/rubocop-hq/rubocop-rails/pull/98): Mark `Rails/ActiveRecordAliases` as `SafeAutoCorrect` false and disable autocorrect by default. ([@prathamesh-sonpatki][])
+
 ## 2.2.1 (2019-07-13)
 
 ### Bug fixes
@@ -54,3 +58,4 @@
 [@fedeagripa]: https://github.com/fedeagripa
 [@brunvez]: https://github.com/brunvez
 [@santib]: https://github.com/santib
+[@prathamesh-sonpatki]: https://github.com/prathamesh-sonpatki

--- a/config/default.yml
+++ b/config/default.yml
@@ -31,6 +31,7 @@ Rails/ActiveRecordAliases:
                   Use `update!` instead of `update_attributes!`.
   Enabled: true
   VersionAdded: '0.53'
+  SafeAutoCorrect: false
 
 Rails/ActiveRecordOverride:
   Description: >-

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -51,7 +51,7 @@ Include | `app/controllers/**/*.rb` | Array
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 0.53 | -
+Enabled | Yes | Yes (Unsafe) | 0.53 | -
 
 Checks that ActiveRecord aliases are not used. The direct method names
 are more clear and easier to read.


### PR DESCRIPTION
We faced an issue where our custom `update_attributes` method call was changed to `update` but the method name remained same in the method definition.

### Original code

```ruby
def update_attributes
end

update_attributes
```

### After running rubocop --safe-auto-correct:

```ruby
def update_attributes
end

update
```

So the cop is not safe for auto correct.

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
