### PR TITLE
Mark Rails/SaveBang as unsafe autocorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Changes
 
 * [#98](https://github.com/rubocop-hq/rubocop-rails/pull/98): Mark `Rails/ActiveRecordAliases` as `SafeAutoCorrect` false and disable autocorrect by default. ([@prathamesh-sonpatki][])
+* [#101](https://github.com/rubocop-hq/rubocop-rails/pull/101): Mark `Rails/SaveBang` as `SafeAutoCorrect` false and disable autocorrect by default. ([@prathamesh-sonpatki][])
 
 ## 2.2.1 (2019-07-13)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -404,6 +404,7 @@ Rails/SaveBang:
   VersionChanged: '0.59'
   AllowImplicitReturn: true
   AllowedReceivers: []
+  SafeAutoCorrect: false
 
 Rails/ScopeArgs:
   Description: 'Checks the arguments of ActiveRecord scopes.'

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -2064,7 +2064,7 @@ ConvertTry | `false` | Boolean
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Disabled | Yes | Yes  | 0.42 | 0.59
+Disabled | Yes | Yes (Unsafe) | 0.42 | 0.59
 
 This cop identifies possible cases where Active Record save! or related
 should be used instead of save because the model might have failed to


### PR DESCRIPTION
We faced an issue where our custom `update` method call was changed to `update!` but the method name remained same in the method definition.

```ruby
def update
end

update!
```

```ruby
def update
end

update
```

So the cop is not safe for auto correct.

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
