### PR TITLE
[Fix #104] Exclude Rails-independent `bin/bundle` by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#104](https://github.com/rubocop-hq/rubocop-rails/issues/104): Exclude Rails-independent `bin/bundle` by default. ([@koic][])
+
 ## 2.3.0 (2019-08-13)
 
 ### New features

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,6 +1,8 @@
 # Common configuration.
 
 AllCops:
+  Exclude:
+    - bin/bundle
   # What version of Rails is the inspected code using?  If a value is specified
   # for TargetRailsVersion then it is used.  Acceptable values are specificed
   # as a float (i.e. 5.1); the patch version of Rails should not be included.


### PR DESCRIPTION
Resolves #104.

`bin/bundle` was generated by Bundler. And Bundler doesn't depend on Active Support (Rails).

This PR prevents the following error.

```console
% cd path/to/new-rails-app
% bin/rails -v
Rails 6.0.0.rc2
% bundle exec rubocop -a --only Rails/Present
% g diff
diff --git a/bin/bundle b/bin/bundle
index 4f5e057..fa7b83b 100755
--- a/bin/bundle
+++ b/bin/bundle
@@ -39,7 +39,7 @@ m = Module.new do

   def gemfile
     gemfile = ENV["BUNDLE_GEMFILE"]
-    return gemfile if gemfile && !gemfile.empty?
+    return gemfile if gemfile.present?

     File.expand_path("../../Gemfile", __FILE__)
   end
% ./bin/bundle
Traceback (most recent call last):
        2: from ./bin/bundle:101:in `<main>'
        1: from ./bin/bundle:71:in `load_bundler!'
./bin/bundle:42:in `gemfile': undefined method `present?' for
   nil:NilClass (NoMethodError)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
