### PR TITLE
[Fix #107] Fix style guide URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#104](https://github.com/rubocop-hq/rubocop-rails/issues/104): Exclude Rails-independent `bin/bundle` by default. ([@koic][])
+* [#107](https://github.com/rubocop-hq/rubocop-rails/issues/107): Fix style guide URLs when specifying `rubocop --display-style-guide` option. ([@koic][])
 
 ## 2.3.0 (2019-08-13)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -11,9 +11,6 @@ AllCops:
   # application.  If neither of those files exist, RuboCop will use Rails 5.0
   # as the default.
   TargetRailsVersion: ~
-  # When specifying style guide URLs, any paths and/or fragments will be
-  # evaluated relative to the base URL.
-  StyleGuideBaseURL: https://rails.rubystyle.guide
 
 Rails/ActionFilter:
   Description: 'Enforces consistent use of action filter methods.'
@@ -142,7 +139,7 @@ Rails/DelegateAllowBlank:
 
 Rails/DynamicFindBy:
   Description: 'Use `find_by` instead of dynamic `find_by_*`.'
-  StyleGuide: '#find_by'
+  StyleGuide: 'https://rails.rubystyle.guide#find_by'
   Enabled: true
   VersionAdded: '0.44'
   Whitelist:
@@ -150,7 +147,7 @@ Rails/DynamicFindBy:
 
 Rails/EnumHash:
   Description: 'Prefer hash syntax over array syntax when defining enums.'
-  StyleGuide: '#enums'
+  StyleGuide: 'https://rails.rubystyle.guide#enums'
   Enabled: true
   VersionAdded: '2.3'
   Include:
@@ -194,7 +191,7 @@ Rails/FilePath:
 
 Rails/FindBy:
   Description: 'Prefer find_by over where.first.'
-  StyleGuide: '#find_by'
+  StyleGuide: 'https://rails.rubystyle.guide#find_by'
   Enabled: true
   VersionAdded: '0.30'
   Include:
@@ -202,7 +199,7 @@ Rails/FindBy:
 
 Rails/FindEach:
   Description: 'Prefer all.find_each over all.find.'
-  StyleGuide: '#find-each'
+  StyleGuide: 'https://rails.rubystyle.guide#find-each'
   Enabled: true
   VersionAdded: '0.30'
   Include:
@@ -210,7 +207,7 @@ Rails/FindEach:
 
 Rails/HasAndBelongsToMany:
   Description: 'Prefer has_many :through to has_and_belongs_to_many.'
-  StyleGuide: '#has-many-through'
+  StyleGuide: 'https://rails.rubystyle.guide#has-many-through'
   Enabled: true
   VersionAdded: '0.12'
   Include:
@@ -218,7 +215,7 @@ Rails/HasAndBelongsToMany:
 
 Rails/HasManyOrHasOneDependent:
   Description: 'Define the dependent option to the has_many and has_one associations.'
-  StyleGuide: '#has_many-has_one-dependent-option'
+  StyleGuide: 'https://rails.rubystyle.guide#has_many-has_one-dependent-option'
   Enabled: true
   VersionAdded: '0.50'
   Include:
@@ -265,7 +262,7 @@ Rails/InverseOf:
 
 Rails/LexicallyScopedActionFilter:
   Description: "Checks that methods specified in the filter's `only` or `except` options are explicitly defined in the controller."
-  StyleGuide: '#lexically-scoped-action-filter'
+  StyleGuide: 'https://rails.rubystyle.guide#lexically-scoped-action-filter'
   Enabled: true
   Safe: false
   VersionAdded: '0.52'
@@ -330,7 +327,7 @@ Rails/ReadWriteAttribute:
   Description: >-
                  Checks for read_attribute(:attr) and
                  write_attribute(:attr, val).
-  StyleGuide: '#read-attribute'
+  StyleGuide: 'https://rails.rubystyle.guide#read-attribute'
   Enabled: true
   VersionAdded: '0.20'
   VersionChanged: '0.29'
@@ -381,7 +378,7 @@ Rails/RequestReferer:
 
 Rails/ReversibleMigration:
   Description: 'Checks whether the change method of the migration file is reversible.'
-  StyleGuide: '#reversible-migration'
+  StyleGuide: 'https://rails.rubystyle.guide#reversible-migration'
   Reference: 'https://api.rubyonrails.org/classes/ActiveRecord/Migration/CommandRecorder.html'
   Enabled: true
   VersionAdded: '0.47'
@@ -400,7 +397,7 @@ Rails/SafeNavigation:
 
 Rails/SaveBang:
   Description: 'Identifies possible cases where Active Record save! or related should be used.'
-  StyleGuide: '#save-bang'
+  StyleGuide: 'https://rails.rubystyle.guide#save-bang'
   Enabled: false
   VersionAdded: '0.42'
   VersionChanged: '0.59'
@@ -439,7 +436,7 @@ Rails/SkipsModelValidations:
 
 Rails/TimeZone:
   Description: 'Checks the correct usage of time zone aware methods.'
-  StyleGuide: '#time'
+  StyleGuide: 'https://rails.rubystyle.guide#time'
   Reference: 'http://danilenko.org/2012/7/6/rails_timezones'
   Enabled: true
   Safe: false


### PR DESCRIPTION
Fixes #107.

This PR fixes style guide URLs when specifying `rubocop --display-style-guide` option.

The following is an execution using RuboCop Rails.

```console
% bundle exec rubocop --display-style-guide --only Style/StringLiterals
Inspecting 2 files
C.

Offenses:

Gemfile:3:8: C: Style/StringLiterals: Prefer single-quoted strings when
you don't need string interpolation or special
symbols. (https://rails.rubystyle.guide#consistent-string-literals)
source "https://rubygems.org"
       ^^^^^^^^^^^^^^^^^^^^^^

2 files inspected, 1 offense detected
```

The correct URL is `https://rubystyle.guide#consistent-string-literals` instead of `https://rails.rubystyle.guide#consistent-string-literals`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
