### PR TITLE
EnumHash breaks on nested constants

### DIFF
--- a/spec/rubocop/cop/rails/enum_hash_spec.rb
+++ b/spec/rubocop/cop/rails/enum_hash_spec.rb
@@ -90,6 +90,21 @@ RSpec.describe RuboCop::Cop::Rails::EnumHash do
         enum status: {:old=>0, :"very active"=>1, "is archived"=>2, 42=>3}
       RUBY
     end
+
+    it 'autocorrects nested constants' do
+      expect_offense(<<~RUBY)
+        STATUS::OLD = :old
+        STATUS::ACTIVE = :active
+        enum status: [STATUS::OLD, STATUS::ACTIVE]
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        STATUS::OLD = :old
+        STATUS::ACTIVE = :active
+        enum status: {STATUS::OLD=>0, STATUS::ACTIVE=>1}
+      RUBY
+    end
   end
 
   context 'when hash syntax is used' do


### PR DESCRIPTION
The test case below should pass, but instead fails with:

```diff
-enum status: {STATUS::OLD=>0, STATUS::ACTIVE=>1}
+enum status: {s(:const, nil, :STATUS)=>1}
```

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
