### PR TITLE
[Fix #111] Fix an incorrect autocorrect for `Rails/Presence`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#104](https://github.com/rubocop-hq/rubocop-rails/issues/104): Exclude Rails-independent `bin/bundle` by default. ([@koic][])
 * [#107](https://github.com/rubocop-hq/rubocop-rails/issues/107): Fix style guide URLs when specifying `rubocop --display-style-guide` option. ([@koic][])
+* [#111](https://github.com/rubocop-hq/rubocop-rails/issues/111): Fix an incorrect autocorrect for `Rails/Presence` when method arguments of `else` branch is not enclosed in parentheses. ([@koic][])
 
 ## 2.3.0 (2019-08-13)
 

--- a/spec/rubocop/cop/rails/presence_spec.rb
+++ b/spec/rubocop/cop/rails/presence_spec.rb
@@ -73,6 +73,58 @@ RSpec.describe RuboCop::Cop::Rails::Presence do
                 .map { |num| num + 2 }.presence || b
   FIXED
 
+  context 'when a method argument of `else` branch ' \
+          'is enclosed in parentheses' do
+    it_behaves_like 'offense', <<~SOURCE.chomp, <<~CORRECTION.chomp, 1, 5
+      if value.present?
+        value
+      else
+        do_something(value)
+      end
+    SOURCE
+      value.presence || do_something(value)
+    CORRECTION
+  end
+
+  context 'when a method argument of `else` branch ' \
+          'is not enclosed in parentheses' do
+    it_behaves_like 'offense', <<~SOURCE.chomp, <<~CORRECTION.chomp, 1, 5
+      if value.present?
+        value
+      else
+        do_something value
+      end
+    SOURCE
+      value.presence || do_something(value)
+    CORRECTION
+  end
+
+  context 'when multiple method arguments of `else` branch ' \
+          'is not enclosed in parentheses' do
+    it_behaves_like 'offense', <<~SOURCE.chomp, <<~CORRECTION.chomp, 1, 5
+      if value.present?
+        value
+      else
+        do_something arg1, arg2
+      end
+    SOURCE
+      value.presence || do_something(arg1, arg2)
+    CORRECTION
+  end
+
+  context 'when a method argument with a receiver of `else` branch ' \
+          'is not enclosed in parentheses' do
+    it_behaves_like 'offense', <<~SOURCE.chomp, <<~CORRECTION.chomp, 1, 5
+      if value.present?
+        value
+      else
+        foo.do_something value
+      end
+    SOURCE
+      value.presence || foo.do_something(value)
+    CORRECTION
+  end
+
   it 'does not register an offense when using `#presence`' do
     expect_no_offenses(<<~RUBY)
       a.presence


### PR DESCRIPTION
Fixes #111.

This PR fixes an incorrect autocorrect for `Rails/Presence` when method arguments of `else` branch is not enclosed in parentheses.

The following is a reproduction procedure.

```console
% cat example.rb
if value.present?
  value
else
  do_something value
end
```

```console
% bundle exec rubocop -a --only Rails/Presence
Inspecting 1 file
E

Offenses:

example.rb:1:1: C: [Corrected] Rails/Presence: Use value.presence ||
do_something value instead of if value.present?
  value
else
  do_something value
end.
if value.present? ...
^^^^^^^^^^^^^^^^^
example.rb:1:32: E: Lint/Syntax: unexpected token tIDENTIFIER
(Using Ruby 2.7 parser; configure using TargetRubyVersion parameter,
under AllCops)
value.presence || do_something value
                               ^^^^^

1 file inspected, 2 offenses detected, 1 offense corrected
```

```console
% cat example.rb
value.presence || do_something value
```

The auto-corrected code is a syntax error.

```console
% ruby example.rb
example.rb:3: syntax error, unexpected local variable or method,
expecting `do' or '{' or '('
....presence || do_something value
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
