### PR TITLE
[Fix #116] Fix an incorrect autocorrect for `Rails/Prensence`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#118](https://github.com/rubocop-hq/rubocop-rails/issues/118): Fix an incorrect autocorrect for `Rails/Validation` when attributes are specified with array literal. ([@koic][])
+* [#116](https://github.com/rubocop-hq/rubocop-rails/issues/116): Fix an incorrect autocorrect for `Rails/Presence` when `else` branch of ternary operator is not nil. ([@koic][])
 
 ## 2.3.1 (2019-08-26)
 

--- a/lib/rubocop/cop/rails/presence.rb
+++ b/lib/rubocop/cop/rails/presence.rb
@@ -119,8 +119,10 @@ module RuboCop
         def replacement(receiver, other)
           or_source = if other&.send_type?
                         build_source_for_or_method(other)
-                      else
+                      elsif other.nil? || other.nil_type?
                         ''
+                      else
+                        " || #{other.source}"
                       end
 
           "#{receiver.source}.presence" + or_source

--- a/spec/rubocop/cop/rails/presence_spec.rb
+++ b/spec/rubocop/cop/rails/presence_spec.rb
@@ -36,6 +36,8 @@ RSpec.describe RuboCop::Cop::Rails::Presence do
   it_behaves_like 'offense', '!a.present? ? b : a', 'a.presence || b', 1, 1
   it_behaves_like 'offense', 'a.blank? ? b : a', 'a.presence || b', 1, 1
   it_behaves_like 'offense', '!a.blank? ? a : b', 'a.presence || b', 1, 1
+  it_behaves_like 'offense', 'a.present? ? a : 1', 'a.presence || 1', 1, 1
+  it_behaves_like 'offense', 'a.blank? ? 1 : a', 'a.presence || 1', 1, 1
 
   it_behaves_like 'offense',
                   'a(:bar).map(&:baz).present? ? a(:bar).map(&:baz) : nil',


### PR DESCRIPTION
Fixes #116 and adds regression tests for #115.

This PR fixes an incorrect autocorrect for `Rails/Presence` when `else` branch of ternary operator is not nil.

The following is a reproduction procedure.

```ruby
# example.rb
a.blank? ? 1 : a
```

```console
% bundle exec rubocop --only Rails/Presence -a
Inspecting 1 file
C

Offenses:

example.rb:1:1: C: [Corrected] Rails/Presence: Use a.presence instead of
a.blank? ? 1 : a.
a.blank? ? 1 : a
^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected
```

```diff
-a.blank? ? 1 : a
+a.presence
```

This PR will auto-correct it to `a.presence || 1`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
