### PR TITLE
[Fix #118] Fix an incorrect autocorrect for `Rails/Validation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#118](https://github.com/rubocop-hq/rubocop-rails/issues/118): Fix an incorrect autocorrect for `Rails/Validation` when attributes are specified with array literal. ([@koic][])
+
 ## 2.3.1 (2019-08-26)
 
 ### Bug fixes

--- a/lib/rubocop/cop/rails/validation.rb
+++ b/lib/rubocop/cop/rails/validation.rb
@@ -61,7 +61,8 @@ module RuboCop
 
         def autocorrect(node)
           last_argument = node.arguments.last
-          return if !last_argument.literal? && !last_argument.splat_type?
+          return if !last_argument.literal? && !last_argument.splat_type? &&
+                    !frozen_array_argument?(last_argument)
 
           lambda do |corrector|
             corrector.replace(node.loc.selector, 'validates')
@@ -81,15 +82,19 @@ module RuboCop
         end
 
         def correct_validate_type(corrector, node)
-          last_argument = node.arguments.last
+          last_argument = node.last_argument
 
           if last_argument.hash_type?
-            corrector.replace(
-              last_argument.loc.expression,
-              "#{validate_type(node)}: #{braced_options(last_argument)}"
-            )
+            correct_validate_type_for_hash(corrector, node, last_argument)
           elsif last_argument.array_type?
-            correct_validate_type_for_array_argument(corrector, node)
+            loc = last_argument.loc
+
+            correct_validate_type_for_array(corrector, node, last_argument, loc)
+          elsif frozen_array_argument?(last_argument)
+            arguments = node.last_argument.receiver
+            loc = arguments.parent.loc
+
+            correct_validate_type_for_array(corrector, node, arguments, loc)
           else
             range = last_argument.source_range
 
@@ -97,9 +102,14 @@ module RuboCop
           end
         end
 
-        def correct_validate_type_for_array_argument(corrector, node)
-          arguments = node.last_argument
+        def correct_validate_type_for_hash(corrector, node, arguments)
+          corrector.replace(
+            arguments.loc.expression,
+            "#{validate_type(node)}: #{braced_options(arguments)}"
+          )
+        end
 
+        def correct_validate_type_for_array(corrector, node, arguments, loc)
           attributes = []
 
           arguments.each_child_node do |child_node|
@@ -111,13 +121,17 @@ module RuboCop
           end
 
           corrector.replace(
-            arguments.loc.expression,
+            loc.expression,
             "#{attributes.join(', ')}, #{validate_type(node)}: true"
           )
         end
 
         def validate_type(node)
           node.method_name.to_s.split('_')[1]
+        end
+
+        def frozen_array_argument?(argument)
+          argument.send_type? && argument.method?(:freeze)
         end
 
         def braced_options(options)

--- a/spec/rubocop/cop/rails/validation_spec.rb
+++ b/spec/rubocop/cop/rails/validation_spec.rb
@@ -73,6 +73,19 @@ RSpec.describe RuboCop::Cop::Rails::Validation do
       end
 
       context "with validates_#{type}_of when " \
+              'attributes are specified with frozen array literal' do
+        let(:auto_corrected_source) do
+          "validates :full_name, :birth_date, #{type}: true"
+        end
+
+        let(:source) do
+          "validates_#{type}_of [:full_name, :birth_date].freeze"
+        end
+
+        include_examples 'auto-corrects'
+      end
+
+      context "with validates_#{type}_of when " \
               'attributes are specified with symbol array literal' do
         let(:auto_corrected_source) do
           "validates :full_name, :birth_date, #{type}: true"
@@ -80,6 +93,19 @@ RSpec.describe RuboCop::Cop::Rails::Validation do
 
         let(:source) do
           "validates_#{type}_of %i[full_name birth_date]"
+        end
+
+        include_examples 'auto-corrects'
+      end
+
+      context "with validates_#{type}_of when " \
+              'attributes are specified with frozen symbol array literal' do
+        let(:auto_corrected_source) do
+          "validates :full_name, :birth_date, #{type}: true"
+        end
+
+        let(:source) do
+          "validates_#{type}_of %i[full_name birth_date].freeze"
         end
 
         include_examples 'auto-corrects'

--- a/spec/rubocop/cop/rails/validation_spec.rb
+++ b/spec/rubocop/cop/rails/validation_spec.rb
@@ -58,6 +58,32 @@ RSpec.describe RuboCop::Cop::Rails::Validation do
 
         include_examples 'auto-corrects'
       end
+
+      context "with validates_#{type}_of when " \
+              'attributes are specified with array literal' do
+        let(:auto_corrected_source) do
+          "validates :full_name, :birth_date, #{type}: true"
+        end
+
+        let(:source) do
+          "validates_#{type}_of [:full_name, :birth_date]"
+        end
+
+        include_examples 'auto-corrects'
+      end
+
+      context "with validates_#{type}_of when " \
+              'attributes are specified with symbol array literal' do
+        let(:auto_corrected_source) do
+          "validates :full_name, :birth_date, #{type}: true"
+        end
+
+        let(:source) do
+          "validates_#{type}_of %i[full_name birth_date]"
+        end
+
+        include_examples 'auto-corrects'
+      end
     end
 
     context 'with single attribute name' do


### PR DESCRIPTION
Fixes #118.

This PR fixes an incorrect autocorrect for `Rails/Validation` when attributes are specified with symbol array literal.

The following auto-corrected causes `NoMethodError`.

```ruby
validates %i[full_name birth_date], presence: true

# => validates_with': undefined method `to_sym' for
#    [:full_name, :birth_date]:Array (NoMethodError)
```

This PR will auto-correct it to the following code.

```ruby
validates :full_name, :birth_date, presence: true
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
