### PR TITLE
Replace use of strip_indent with squiggly heredoc

### DIFF
--- a/spec/rubocop/cop/rails/bulk_change_table_spec.rb
+++ b/spec/rubocop/cop/rails/bulk_change_table_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe RuboCop::Cop::Rails::BulkChangeTable, :config do
     end
 
     it 'does not register an offense for `change_column_null`' do
-      expect_no_offenses(<<-RUBY.strip_indent)
+      expect_no_offenses(<<~RUBY)
         def change
           change_column_null :users, :name, false
           change_column_null :users, :address, false
@@ -154,7 +154,7 @@ RSpec.describe RuboCop::Cop::Rails::BulkChangeTable, :config do
         end
       RUBY
 
-      expect_no_offenses(<<-RUBY.strip_indent)
+      expect_no_offenses(<<~RUBY)
         def change
           change_column_null :users, :name, false
           change_column_null :users, :address, false

--- a/spec/rubocop/cop/rails/file_path_spec.rb
+++ b/spec/rubocop/cop/rails/file_path_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
 
     context 'when using Rails.root.join in string interpolation of argument' do
       it 'registers an offense' do
-        expect_offense(<<-'RUBY'.strip_indent)
+        expect_offense(<<~'RUBY')
           system "rm -rf #{Rails.root.join('a', 'b.png')}"
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Please use `Rails.root.join('path/to')` instead.
         RUBY
@@ -26,7 +26,7 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
 
     context 'when using string interpolation without Rails.root' do
       it 'does not register an offense' do
-        expect_no_offenses(<<-'RUBY'.strip_indent)
+        expect_no_offenses(<<~'RUBY')
           repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?('/')
         RUBY
       end
@@ -34,7 +34,7 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
 
     context 'when using File::SEPARATOR string without Rails.root' do
       it 'does not register an offense' do
-        expect_no_offenses(<<-'RUBY'.strip_indent)
+        expect_no_offenses(<<~'RUBY')
           "#{42}/"
         RUBY
       end
@@ -57,7 +57,7 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
 
     context 'when using Rails.root called by double quoted string' do
       it 'registers an offense' do
-        expect_offense(<<-'RUBY'.strip_indent)
+        expect_offense(<<~'RUBY')
           "#{Rails.root}/app/models/goober"
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Please use `Rails.root.join('path/to')` instead.
         RUBY
@@ -67,7 +67,7 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
     context 'when concat Rails.root and file separator ' \
             'using string interpolation' do
       it 'registers an offense' do
-        expect_offense(<<-'RUBY'.strip_indent)
+        expect_offense(<<~'RUBY')
           system "rm -rf #{Rails.root}/foo/bar"
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Please use `Rails.root.join('path/to')` instead.
         RUBY
@@ -77,7 +77,7 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
     context 'when concat Rails.root.join and extension ' \
             'using string interpolation' do
       it 'registers an offense' do
-        expect_offense(<<-'RUBY'.strip_indent)
+        expect_offense(<<~'RUBY')
           "#{Rails.root.join('tmp', user.id, 'icon')}.png"
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Please use `Rails.root.join('path/to')` instead.
         RUBY
@@ -129,7 +129,7 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
 
     context 'when using Rails.root.join in string interpolation of argument' do
       it 'does not registers an offense' do
-        expect_no_offenses(<<-'RUBY'.strip_indent)
+        expect_no_offenses(<<~'RUBY')
           'system "rm -rf #{Rails.root.join(\'a\', \'b.png\')}"'
         RUBY
       end
@@ -137,7 +137,7 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
 
     context 'when using string interpolation without Rails.root' do
       it 'does not registers an offense' do
-        expect_no_offenses(<<-'RUBY'.strip_indent)
+        expect_no_offenses(<<~'RUBY')
           repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?('/')
         RUBY
       end
@@ -145,7 +145,7 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
 
     context 'when using File::SEPARATOR string without Rails.root' do
       it 'does not registers an offense' do
-        expect_no_offenses(<<-'RUBY'.strip_indent)
+        expect_no_offenses(<<~'RUBY')
           "#{42}/"
         RUBY
       end
@@ -171,7 +171,7 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
 
     context 'when using Rails.root called by double quoted string' do
       it 'registers an offense' do
-        expect_offense(<<-'RUBY'.strip_indent)
+        expect_offense(<<~'RUBY')
           "#{Rails.root}/app/models/goober"
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Please use `Rails.root.join('path', 'to')` instead.
         RUBY
@@ -181,7 +181,7 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
     context 'when concat Rails.root and file separator ' \
             'using string interpolation' do
       it 'registers an offense' do
-        expect_offense(<<-'RUBY'.strip_indent)
+        expect_offense(<<~'RUBY')
           system "rm -rf #{Rails.root}/foo/bar"
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Please use `Rails.root.join('path', 'to')` instead.
         RUBY
@@ -191,7 +191,7 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
     context 'when concat Rails.root.join and extension ' \
             'using string interpolation' do
       it 'registers an offense' do
-        expect_offense(<<-'RUBY'.strip_indent)
+        expect_offense(<<~'RUBY')
           "#{Rails.root.join('tmp', user.id, 'icon')}.png"
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Please use `Rails.root.join('path', 'to')` instead.
         RUBY

--- a/spec/rubocop/cop/rails/helper_instance_variable_spec.rb
+++ b/spec/rubocop/cop/rails/helper_instance_variable_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RuboCop::Cop::Rails::HelperInstanceVariable do
   subject(:cop) { described_class.new }
 
   it 'reports uses of instance variables' do
-    expect_offense(<<-'RUBY'.strip_indent)
+    expect_offense(<<~'RUBY')
       def welcome_message
         "Hello #{@user.name}"
                  ^^^^^ Do not use instance variables in helpers.
@@ -13,7 +13,7 @@ RSpec.describe RuboCop::Cop::Rails::HelperInstanceVariable do
   end
 
   it 'reports instance variable assignments' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       def welcome_message(user)
         @user_name = user.name
         ^^^^^^^^^^ Do not use instance variables in helpers.
@@ -22,7 +22,7 @@ RSpec.describe RuboCop::Cop::Rails::HelperInstanceVariable do
   end
 
   specify do
-    expect_no_offenses(<<-'RUBY'.strip_indent)
+    expect_no_offenses(<<~'RUBY')
       def welcome_message(user)
         "Hello #{user.name}"
       end

--- a/spec/rubocop/cop/rails/output_safety_spec.rb
+++ b/spec/rubocop/cop/rails/output_safety_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe RuboCop::Cop::Rails::OutputSafety do
     end
 
     it 'registers an offense for dynamic string literal receiver' do
-      expect_offense(<<-'RUBY'.strip_indent)
+      expect_offense(<<~'RUBY')
         "foo#{1}".html_safe
                   ^^^^^^^^^ Tagging a string as html safe may be a security risk.
       RUBY


### PR DESCRIPTION
The `strip_indent` method was removed from RuboCop in https://github.com/rubocop-hq/rubocop/pull/7323.

Since rubocop-rails has never supported Ruby 2.2, we can safely replace all instances of `strip_indent` with squiggly heredocs.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] ~Added tests~ Fixed tests. 😄 
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/