### PR TITLE
Add rationale for Rails/FilePath rule

### DIFF
--- a/lib/rubocop/cop/rails/file_path.rb
+++ b/lib/rubocop/cop/rails/file_path.rb
@@ -6,6 +6,8 @@ module RuboCop
       # This cop is used to identify usages of file path joining process
       # to use `Rails.root.join` clause. It is used to add uniformity when
       # joining paths.
+      # 
+      # This is to avoid bugs on operating systems, such as Windows, that don't use '/' as the path separator.
       #
       # @example EnforcedStyle: arguments (default)
       #   # bad


### PR DESCRIPTION
This was previously included in the documentation before rubocop-rails was split off from Rubocop: https://web.archive.org/web/20180307163045/https://rubocop.readthedocs.io/en/latest/cops_rails/#railsfilepath