### PR TITLE
Add `require 'English'` to enable `$RS` global variable

### DIFF
--- a/rubocop-rails.gemspec
+++ b/rubocop-rails.gemspec
@@ -2,6 +2,7 @@
 
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'rubocop/rails/version'
+require 'English'
 
 Gem::Specification.new do |s|
   s.name = 'rubocop-rails'


### PR DESCRIPTION
`$RS` is defined in English library, but the gemspec does not require it. So `$RS` is `nil`.

I found the problem with Ruby warning.


```bash
$ ruby -w rubocop-rails.gemspec
rubocop-rails.gemspec:19: warning: global variable `$RS' not initialized
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
