### PR TITLE
presence cop: fix [] for ternary expr other hand

### DIFF
--- a/lib/rubocop/cop/rails/presence.rb
+++ b/lib/rubocop/cop/rails/presence.rb
@@ -129,7 +129,7 @@ module RuboCop
         end
 
         def build_source_for_or_method(other)
-          if other.parenthesized? || !other.arguments?
+          if other.parenthesized? || other.method?('[]') || !other.arguments?
             " || #{other.source}"
           else
             method = range_between(

--- a/spec/rubocop/cop/rails/presence_spec.rb
+++ b/spec/rubocop/cop/rails/presence_spec.rb
@@ -44,6 +44,11 @@ RSpec.describe RuboCop::Cop::Rails::Presence do
                   'a(:bar).map(&:baz).presence',
                   1, 1
 
+  it_behaves_like 'offense',
+                  'a.present? ? a : b[:c]',
+                  'a.presence || b[:c]',
+                  1, 1
+
   it_behaves_like 'offense', <<~RUBY.chomp, 'a.presence', 1, 5
     if a.present?
       a


### PR DESCRIPTION
## synopsis

when trying autofix code like below:

`params[:foo].present? ? params[:foo] : params[:bar]`

the existing code will change it to:

`params[:foo].presence || params(:bar)`

essentially replaces the content of the `else` or `other` end of the ternary expression.

## investigation and fix

the culprit is this method `build_source_for_or_method` did not consider the parameter `other` (which is a `SendNode`) might be a `[]` method call.

this tiny patch fixes it.

That being said, I am not confident that this fixes all related problems.