### PR TITLE
Fix `FrozenError` for save_bang_spec.rb

### DIFF
--- a/spec/rubocop/cop/rails/save_bang_spec.rb
+++ b/spec/rubocop/cop/rails/save_bang_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe RuboCop::Cop::Rails::SaveBang, :config do
     end
 
     it "when using #{method} without arguments" do
-      inspect_source(method.to_s)
+      inspect_source(+method.to_s)
 
       expect(cop.messages)
         .to eq(["Use `#{method}!` instead of `#{method}` " \


### PR DESCRIPTION
Follow ruby/ruby#2437.

This PR fixes the following `FrozenError` for save_bang_spec.rb

```Failures:
% ruby -v
ruby 2.7.0dev (2019-10-09T16:08:42Z master 42edb05626) [x86_64-darwin17]
% bundle exec rspec ./spec/rubocop/cop/rails/save_bang_spec.rb
(snip)

  1) RuboCop::Cop::Rails::SaveBang update behaves like
checks_common_offense when using update without arguments
     Failure/Error: inspect_source(method.to_s)

     FrozenError:
       can't modify frozen String: "update"
     Shared Example Group: "checks_common_offense" called from
./spec/rubocop/cop/rails/save_bang_spec.rb:541
     # ./spec/rubocop/cop/rails/save_bang_spec.rb:58:in `block (3 levels)
in <top (required)>'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
