### PR TITLE
Add release task and release notes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gemspec
 
+gem 'bump', require: false
 gem 'rake'
 gem 'rspec'
 gem 'rubocop', github: 'rubocop-hq/rubocop'

--- a/relnotes/v2.0.0.md
+++ b/relnotes/v2.0.0.md
@@ -1,0 +1,7 @@
+### New features
+
+* Extract Rails cops from rubocop-hq/rubocop repository. ([@koic][])
+* [#19](https://github.com/rubocop-hq/rubocop-rails/issues/19): Add new `Rails/HelperInstanceVariable` cop. ([@andyw8][])
+
+[@koic]: https://github.com/koic
+[@andyw8]: https://github.com/andyw8

--- a/relnotes/v2.0.1.md
+++ b/relnotes/v2.0.1.md
@@ -1,0 +1,5 @@
+### Changes
+
+* [#68](https://github.com/rubocop-hq/rubocop-rails/pull/68): Relax rack dependency for Rails 4. ([@buehmann][])
+
+[@buehmann]: https://github.com/buehmann

--- a/relnotes/v2.1.0.md
+++ b/relnotes/v2.1.0.md
@@ -1,0 +1,12 @@
+### Bug fixes
+
+* [#43](https://github.com/rubocop-hq/rubocop-rails/issues/43): Remove `change_column_null` method from `BulkChangeTable` cop offenses. ([@anthony-robin][])
+* [#79](https://github.com/rubocop-hq/rubocop-rails/issues/79): Fix `RuboCop::Cop::Rails not defined (NameError)`. ([@rmm5t][])
+
+### Changes
+
+* [#74](https://github.com/rubocop-hq/rubocop-rails/pull/74): Drop Rails 3 support. ([@koic][])
+
+[@andyw8]: https://github.com/andyw8
+[@rmm5t]: https://github.com/rmm5t
+[@koic]: https://github.com/koic

--- a/relnotes/v2.2.0.md
+++ b/relnotes/v2.2.0.md
@@ -1,0 +1,5 @@
+### Bug fixes
+
+* [#67](https://github.com/rubocop-hq/rubocop-rails/issues/67): Fix an incorrect auto-correct for `Rails/TimeZone` when using `DateTime`. ([@koic][])
+
+[@koic]: https://github.com/koic

--- a/relnotes/v2.2.1.md
+++ b/relnotes/v2.2.1.md
@@ -1,0 +1,5 @@
+### Bug fixes
+
+* [#86](https://github.com/rubocop-hq/rubocop-rails/issues/86): Fix an incorrect auto-correct for `Rails/TimeZone` when using `Time.new`. ([@koic][])
+
+[@koic]: https://github.com/koic

--- a/relnotes/v2.3.0.md
+++ b/relnotes/v2.3.0.md
@@ -1,0 +1,21 @@
+### New features
+
+* [#78](https://github.com/rubocop-hq/rubocop-rails/issues/78): Add new `Rails/EnumHash` cop. ([@fedeagripa][], [@brunvez][], [@santib][])
+
+### Bug fixes
+
+* [#53](https://github.com/rubocop-hq/rubocop-rails/issues/53): Fix a false positive for `Rails/SaveBang` when implicitly return using finder method and creation method connected by `||`. ([@koic][])
+* [#97](https://github.com/rubocop-hq/rubocop-rails/pull/97): Fix two false negatives for `Rails/EnumUniqueness`. 1. When `enum` name is not a literal. 2. When `enum` has multiple definitions. ([@santib][])
+
+### Changes
+
+* [#98](https://github.com/rubocop-hq/rubocop-rails/pull/98): Mark `Rails/ActiveRecordAliases` as `SafeAutoCorrect` false and disable autocorrect by default. ([@prathamesh-sonpatki][])
+* [#101](https://github.com/rubocop-hq/rubocop-rails/pull/101): Mark `Rails/SaveBang` as `SafeAutoCorrect` false and disable autocorrect by default. ([@prathamesh-sonpatki][])
+* [#102](https://github.com/rubocop-hq/rubocop-rails/pull/102): Include `create_or_find_by` in `Rails/SaveBang` cop. ([@MaximeLaurenty][])
+
+[@fedeagripa]: https://github.com/fedeagripa
+[@brunvez]: https://github.com/brunvez
+[@santib]: https://github.com/santib
+[@koic]: https://github.com/koic
+[@prathamesh-sonpatki]: https://github.com/prathamesh-sonpatki
+[@MaximeLaurenty]: https://github.com/MaximeLaurenty

--- a/relnotes/v2.3.1.md
+++ b/relnotes/v2.3.1.md
@@ -1,0 +1,7 @@
+### Bug fixes
+
+* [#104](https://github.com/rubocop-hq/rubocop-rails/issues/104): Exclude Rails-independent `bin/bundle` by default. ([@koic][])
+* [#107](https://github.com/rubocop-hq/rubocop-rails/issues/107): Fix style guide URLs when specifying `rubocop --display-style-guide` option. ([@koic][])
+* [#111](https://github.com/rubocop-hq/rubocop-rails/issues/111): Fix an incorrect autocorrect for `Rails/Presence` when method arguments of `else` branch is not enclosed in parentheses. ([@koic][])
+
+[@koic]: https://github.com/koic

--- a/relnotes/v2.3.2.md
+++ b/relnotes/v2.3.2.md
@@ -1,0 +1,6 @@
+### Bug fixes
+
+* [#118](https://github.com/rubocop-hq/rubocop-rails/issues/118): Fix an incorrect autocorrect for `Rails/Validation` when attributes are specified with array literal. ([@koic][])
+* [#116](https://github.com/rubocop-hq/rubocop-rails/issues/116): Fix an incorrect autocorrect for `Rails/Presence` when `else` branch of ternary operator is not nil. ([@koic][])
+
+[@koic]: https://github.com/koic

--- a/tasks/cut_release.rake
+++ b/tasks/cut_release.rake
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'bump'
+
+namespace :cut_release do
+  %w[major minor patch pre].each do |release_type|
+    desc "Cut a new #{release_type} release, create release notes " \
+         'and update documents.'
+    task release_type do
+      run(release_type)
+    end
+  end
+
+  def add_header_to_changelog(version)
+    changelog = File.read('CHANGELOG.md')
+    head, tail = changelog.split("## master (unreleased)\n\n", 2)
+
+    File.open('CHANGELOG.md', 'w') do |f|
+      f << head
+      f << "## master (unreleased)\n\n"
+      f << "## #{version} (#{Time.now.strftime('%F')})\n\n"
+      f << tail
+    end
+  end
+
+  def create_release_notes(version)
+    release_notes = new_version_changes.strip
+    contributor_links = user_links(release_notes)
+
+    File.open("relnotes/v#{version}.md", 'w') do |file|
+      file << release_notes
+      file << "\n\n"
+      file << contributor_links
+      file << "\n"
+    end
+  end
+
+  def new_version_changes
+    changelog = File.read('CHANGELOG.md')
+    _, _, new_changes, _older_changes = changelog.split(/^## .*$/, 4)
+    new_changes
+  end
+
+  def user_links(text)
+    names = text.scan(/\[@(\S+)\]\[\]/).map(&:first).uniq
+    names.map { |name| "[@#{name}]: https://github.com/#{name}" }
+         .join("\n")
+  end
+
+  def run(release_type)
+    old_version = Bump::Bump.current
+    Bump::Bump.run(release_type, commit: false, bundle: false, tag: false)
+    new_version = Bump::Bump.current
+
+    add_header_to_changelog(new_version)
+    create_release_notes(new_version)
+
+    puts "Changed version from #{old_version} to #{new_version}."
+  end
+end


### PR DESCRIPTION
This PR adds the following rake tasks.

```console
% rake -T | grep cut_release
rake cut_release:major                    # Cut a new major release,
create release notes and update documents
rake cut_release:minor                    # Cut a new minor release,
create release notes and update documents
rake cut_release:patch                    # Cut a new patch release,
create release notes and update documents
rake cut_release:pre                      # Cut a new pre release,
create release notes and update documents
```

And the release notes from v2.0.0 to v2.3.2 already released will be added.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
