### PR TITLE
Change default of `EnforcedStyle` to `slashes` for `Rails/FilePath`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Changes
 
 * [#156](https://github.com/rubocop-hq/rubocop-rails/pull/156): Make `Rails/UnknownEnv` cop aware of `Rails.env == 'unknown_env'`. ([@pocke][])
+* [#141](https://github.com/rubocop-hq/rubocop-rails/pull/141): Change default of `EnforcedStyle` from `arguments` to `slashes` for `Rails/FilePath`. ([@koic][])
 
 ## 2.3.2 (2019-09-01)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -193,8 +193,8 @@ Rails/FilePath:
   Description: 'Use `Rails.root.join` for file path joining.'
   Enabled: true
   VersionAdded: '0.47'
-  VersionChanged: '0.57'
-  EnforcedStyle: arguments
+  VersionChanged: '2.4'
+  EnforcedStyle: slashes
   SupportedStyles:
     - slashes
     - arguments

--- a/lib/rubocop/cop/rails/file_path.rb
+++ b/lib/rubocop/cop/rails/file_path.rb
@@ -7,7 +7,7 @@ module RuboCop
       # to use `Rails.root.join` clause. It is used to add uniformity when
       # joining paths.
       #
-      # @example EnforcedStyle: arguments (default)
+      # @example EnforcedStyle: arguments
       #   # bad
       #   Rails.root.join('app/models/goober')
       #   File.join(Rails.root, 'app/models/goober')
@@ -16,7 +16,7 @@ module RuboCop
       #   # good
       #   Rails.root.join('app', 'models', 'goober')
       #
-      # @example EnforcedStyle: slashes
+      # @example EnforcedStyle: slashes (default)
       #   # bad
       #   Rails.root.join('app', 'models', 'goober')
       #   File.join(Rails.root, 'app/models/goober')

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -812,7 +812,7 @@ Exclude | `lib/**/*.rake` | Array
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | 0.47 | 0.57
+Enabled | Yes | No | 0.47 | 2.4
 
 This cop is used to identify usages of file path joining process
 to use `Rails.root.join` clause. It is used to add uniformity when
@@ -820,7 +820,7 @@ joining paths.
 
 ### Examples
 
-#### EnforcedStyle: arguments (default)
+#### EnforcedStyle: arguments
 
 ```ruby
 # bad
@@ -831,7 +831,7 @@ File.join(Rails.root, 'app/models/goober')
 # good
 Rails.root.join('app', 'models', 'goober')
 ```
-#### EnforcedStyle: slashes
+#### EnforcedStyle: slashes (default)
 
 ```ruby
 # bad
@@ -847,7 +847,7 @@ Rails.root.join('app/models/goober')
 
 Name | Default value | Configurable values
 --- | --- | ---
-EnforcedStyle | `arguments` | `slashes`, `arguments`
+EnforcedStyle | `slashes` | `slashes`, `arguments`
 
 ## Rails/FindBy
 


### PR DESCRIPTION
This PR changes default of `EnforcedStyle` from `arguments` to `slashes` for `Rails/FilePath`.

The following is why `slashes` by default.

- `Rails.root` is an instance of `Pathname`, so the separator (`/`) works for example on the Windows platform.
- Since it can be expressed by a single string, the number of string instances can be reduced.
- Clarified because the argument is fixed to one.

`EnforcedStyle`'s default was `arguments` because it was mainly due to Windows platform considerations, but it seems to have been a mistake.

https://github.com/rubocop-hq/rubocop-rails/pull/128#issuecomment-530671304

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
