### PR TITLE
Fix an incorrect autocorrect for `Rails/EnumHash`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * [#120](https://github.com/rubocop-hq/rubocop-rails/issues/120): Fix message for `Rails/SaveBang` when the save is in the body of a conditional. ([@jas14][])
 * [#131](https://github.com/rubocop-hq/rubocop-rails/pull/131): Fix an incorrect autocorrect for `Rails/Presence` when using `[]` method. ([@forresty][])
+* [#142](https://github.com/rubocop-hq/rubocop-rails/pull/142): Fix an incorrect autocorrect for `Rails/EnumHash` when using nested constants. ([@koic][])
 
 ## 2.3.2 (2019-09-01)
 

--- a/lib/rubocop/cop/rails/enum_hash.rb
+++ b/lib/rubocop/cop/rails/enum_hash.rb
@@ -41,13 +41,11 @@ module RuboCop
         end
 
         def autocorrect(node)
-          range = node.loc.expression
-          hash = node
-                 .children
-                 .each_with_index
-                 .map { |elem, index| [elem.children.first, index] }.to_h
+          hash = node.children.each_with_index.map do |elem, index|
+            "#{elem.source} => #{index}"
+          end.join(', ')
 
-          ->(corrector) { corrector.replace(range, hash.to_s) }
+          ->(corrector) { corrector.replace(node.loc.expression, "{#{hash}}") }
         end
 
         private

--- a/spec/rubocop/cop/rails/enum_hash_spec.rb
+++ b/spec/rubocop/cop/rails/enum_hash_spec.rb
@@ -87,7 +87,29 @@ RSpec.describe RuboCop::Cop::Rails::EnumHash do
       RUBY
 
       expect_correction(<<~RUBY)
-        enum status: {:old=>0, :"very active"=>1, "is archived"=>2, 42=>3}
+        enum status: {:old => 0, :"very active" => 1, "is archived" => 2, 42 => 3}
+      RUBY
+    end
+
+    it 'autocorrects constants' do
+      expect_offense(<<~RUBY)
+        enum status: [OLD, ACTIVE]
+                     ^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        enum status: {OLD => 0, ACTIVE => 1}
+      RUBY
+    end
+
+    it 'autocorrects nested constants' do
+      expect_offense(<<~RUBY)
+        enum status: [STATUS::OLD, STATUS::ACTIVE]
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        enum status: {STATUS::OLD => 0, STATUS::ACTIVE => 1}
       RUBY
     end
   end


### PR DESCRIPTION
Closes #114.

This PR fixes an incorrect autocorrect for `Rails/EnumHash` when using nested constants.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
