### PR TITLE
Suppress an offense for rails/presence_spec.rb

### DIFF
--- a/spec/rubocop/cop/rails/presence_spec.rb
+++ b/spec/rubocop/cop/rails/presence_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe RuboCop::Cop::Rails::Presence do
 
   it_behaves_like 'offense', 'a if a.present?', 'a.presence', 1, 1
   it_behaves_like 'offense', 'a unless a.blank?', 'a.presence', 1, 1
-  it_behaves_like 'offense', <<~RUBY.chomp, <<~FIXED.chomp, 1, 7 # rubocop:disable Metrics/LineLength
+  it_behaves_like 'offense', <<~RUBY.chomp, <<~FIXED.chomp, 1, 7
     if [1, 2, 3].map { |num| num + 1 }
                 .map { |num| num + 2 }
                 .present?


### PR DESCRIPTION
This PR suppresses the following offense for rails/presence_spec.rb.

```console
% bundle exec rake
(snip)

Offenses:

spec/rubocop/cop/rails/presence_spec.rb:70:66: W:
Lint/UnneededCopDisableDirective: Unnecessary disabling of
Metrics/LineLength.
  it_behaves_like 'offense', <<~RUBY.chomp, <<~FIXED.chomp, 1, 7
  # rubocop:disable Metrics/LineLength
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

126 files inspected, 1 offense detected
RuboCop failed!
```

https://circleci.com/gh/rubocop-hq/rubocop-rails/1721

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
