### PR TITLE
[Fix #144] false positive for `Rails/ReversibleMigration`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 * [#131](https://github.com/rubocop-hq/rubocop-rails/pull/131): Fix an incorrect autocorrect for `Rails/Presence` when using `[]` method. ([@forresty][])
 * [#142](https://github.com/rubocop-hq/rubocop-rails/pull/142): Fix an incorrect autocorrect for `Rails/EnumHash` when using nested constants. ([@koic][])
 * [#136](https://github.com/rubocop-hq/rubocop-rails/pull/136): Fix a false positive for `Rails/ReversibleMigration` when using `change_default` with `:from` and `:to` options. ([@sinsoku][])
+* [#144](https://github.com/rubocop-hq/rubocop-rails/issues/144): Fix a false positive for `Rails/ReversibleMigration` when using change_table_comment with a `:from` and `:to` hash. ([@DNA][])
+
 
 ## 2.3.2 (2019-09-01)
 
@@ -97,3 +99,4 @@
 [@forresty]: https://github.com/forresty
 [@sinsoku]: https://github.com/sinsoku
 [@pocke]: https://github.com/pocke
+[@DNA]: https://github.com/DNA

--- a/spec/rubocop/cop/rails/reversible_migration_spec.rb
+++ b/spec/rubocop/cop/rails/reversible_migration_spec.rb
@@ -126,6 +126,30 @@ RSpec.describe RuboCop::Cop::Rails::ReversibleMigration, :config do
     RUBY
   end
 
+  context 'change_table_comment' do
+    it_behaves_like 'accepts',
+                    'change_table_comment(with :from and :to)', <<-RUBY
+      change_table_comment(:posts, from: nil, to: "draft")
+    RUBY
+
+    it_behaves_like 'offense',
+                    'change_table_comment(without :from and :to)', <<-RUBY
+      change_table_comment(:suppliers, 'new')
+    RUBY
+  end
+
+  context 'change_column_comment' do
+    it_behaves_like 'accepts',
+                    'change_column_comment(with :from and :to)', <<-RUBY
+      change_column_comment(:posts, :state, from: nil, to: "draft")
+    RUBY
+
+    it_behaves_like 'offense',
+                    'change_column_comment(without :from and :to)', <<-RUBY
+      change_column_comment(:suppliers, :qualification, 'new')
+    RUBY
+  end
+
   context 'remove_column' do
     it_behaves_like 'accepts', 'remove_column(with type)', <<-RUBY
       remove_column(:suppliers, :qualification, :string)


### PR DESCRIPTION
Fixes #144

I've made this commit based on `change_column_default` logic, so I'm not sure if the pattern is the best one.

I've also thought about grouping the checks from `change_column_default`, `change_table_comment` and `change_column_comment` into a more generic check that looks if a method has a hash with `:from`/`:to` keys, but I'm not sure if it's the best approach. Let me know which way is better :)

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
