### PR TITLE
Follow renaming Layout/AlignHash to HashAlignment

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,7 +30,7 @@ Style/FormatStringToken:
   Exclude:
     - spec/**/*
 
-Layout/AlignHash:
+Layout/HashAlignment:
   EnforcedHashRocketStyle:
     - key
     - table


### PR DESCRIPTION
Follow https://github.com/rubocop-hq/rubocop/pull/7468

The pull request renamed Layout/AlignHash to Layout/HashAlignment.
Our .rubocop.yml includes the cop, so the CI builds are failing.
example: https://circleci.com/gh/rubocop-hq/rubocop-rails/1776?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

This pull request will fix the problem.