### PR TITLE
Make `Rails/UnknownEnv` cop aware of `Rails.env == 'unknown_env'`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 * [#136](https://github.com/rubocop-hq/rubocop-rails/pull/136): Fix a false positive for `Rails/ReversibleMigration` when using `change_default` with `:from` and `:to` options. ([@sinsoku][])
 * [#144](https://github.com/rubocop-hq/rubocop-rails/issues/144): Fix a false positive for `Rails/ReversibleMigration` when using `change_table_comment` or `change_column_comment` with a `:from` and `:to` hash. ([@DNA][])
 
+### Changes
+
+* [#156](https://github.com/rubocop-hq/rubocop-rails/pull/156): Make `Rails/UnknownEnv` cop aware of `Rails.env == 'unknown_env'`. ([@pocke][])
+
 ## 2.3.2 (2019-09-01)
 
 ### Bug fixes

--- a/lib/rubocop/cop/rails/unknown_env.rb
+++ b/lib/rubocop/cop/rails/unknown_env.rb
@@ -9,9 +9,11 @@ module RuboCop
       # @example
       #   # bad
       #   Rails.env.proudction?
+      #   Rails.env == 'proudction'
       #
       #   # good
       #   Rails.env.production?
+      #   Rails.env == 'production'
       class UnknownEnv < Cop
         include NameSimilarity
 
@@ -19,28 +21,43 @@ module RuboCop
         MSG_SIMILAR = 'Unknown environment `%<name>s`. ' \
                       'Did you mean `%<similar>s`?'
 
-        def_node_matcher :unknown_environment?, <<-PATTERN
+        def_node_matcher :rails_env?, <<~PATTERN
           (send
-            (send
-              {(const nil? :Rails) (const (cbase) :Rails)}
-              :env)
-            $#unknown_env_name?)
+            {(const nil? :Rails) (const (cbase) :Rails)}
+            :env)
+        PATTERN
+
+        def_node_matcher :unknown_environment_predicate?, <<~PATTERN
+          (send #rails_env? $#unknown_env_predicate?)
+        PATTERN
+
+        def_node_matcher :unknown_environment_equal?, <<-PATTERN
+          {
+            (send #rails_env? {:== :===} $(str #unknown_env_name?))
+            (send $(str #unknown_env_name?) {:== :===} #rails_env?)
+          }
         PATTERN
 
         def on_send(node)
-          unknown_environment?(node) do |name|
+          unknown_environment_predicate?(node) do |name|
             add_offense(node, location: :selector, message: message(name))
+          end
+
+          unknown_environment_equal?(node) do |str_node|
+            name = str_node.value
+            add_offense(str_node, message: message(name))
           end
         end
 
         private
 
         def collect_variable_like_names(_scope)
-          environments.map { |env| env + '?' }
+          environments
         end
 
         def message(name)
-          similar = find_similar_name(name.to_s, [])
+          name = name.to_s.chomp('?')
+          similar = find_similar_name(name, [])
           if similar
             format(MSG_SIMILAR, name: name, similar: similar)
           else
@@ -48,10 +65,14 @@ module RuboCop
           end
         end
 
-        def unknown_env_name?(name)
+        def unknown_env_predicate?(name)
           name = name.to_s
           name.end_with?('?') &&
             !environments.include?(name[0..-2])
+        end
+
+        def unknown_env_name?(name)
+          !environments.include?(name)
         end
 
         def environments

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -2502,9 +2502,11 @@ exist.
 ```ruby
 # bad
 Rails.env.proudction?
+Rails.env == 'proudction'
 
 # good
 Rails.env.production?
+Rails.env == 'production'
 ```
 
 ### Configurable attributes

--- a/spec/rubocop/cop/rails/unknown_env_spec.rb
+++ b/spec/rubocop/cop/rails/unknown_env_spec.rb
@@ -14,19 +14,32 @@ RSpec.describe RuboCop::Cop::Rails::UnknownEnv, :config do
   end
 
   it 'registers an offense for typo of environment name' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       Rails.env.proudction?
-                ^^^^^^^^^^^ Unknown environment `proudction?`. Did you mean `production?`?
+                ^^^^^^^^^^^ Unknown environment `proudction`. Did you mean `production`?
       Rails.env.developpment?
-                ^^^^^^^^^^^^^ Unknown environment `developpment?`. Did you mean `development?`?
+                ^^^^^^^^^^^^^ Unknown environment `developpment`. Did you mean `development`?
       Rails.env.something?
-                ^^^^^^^^^^ Unknown environment `something?`.
+                ^^^^^^^^^^ Unknown environment `something`.
+    RUBY
+  end
+
+  it 'registers an offense for typo of environment name with `==` operator' do
+    expect_offense(<<~RUBY)
+      Rails.env == 'proudction'
+                   ^^^^^^^^^^^^ Unknown environment `proudction`. Did you mean `production`?
+      'developpment' == Rails.env
+      ^^^^^^^^^^^^^^ Unknown environment `developpment`. Did you mean `development`?
+
+      'something' === Rails.env
+      ^^^^^^^^^^^ Unknown environment `something`.
     RUBY
   end
 
   it 'accepts correct environment name' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       Rails.env.production?
+      Rails.env == 'production'
     RUBY
   end
 end


### PR DESCRIPTION

`Rails/UnknownEnv` is not aware of `Rails.env == 'unknown_env'` style comparetion.

```ruby
# It has a typo, but the cop does not detect any offense for the code!
if Rails.env == 'proudction'
end
```

This pull request adds the check to Rails/UnknownEnv cop.


Note
===


This pull request also change the offense message.
I removed `?` from the environment name in the message.

```diff
- Unknown environment `proudction?`. Did you mean `production?`?
+ Unknown environment `proudction`. Did you mean `production`?
```


Because `production?` is not an environment name.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
