### PR TITLE
FIX #159 enum hash auto correct for % arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#159](https://github.com/rubocop-hq/rubocop-rails/issues/159): Fix autocorrect for `Rails/EnumHash` when using % arrays notations. ([@ngouy][])
+
 ## 2.4.0 (2019-11-27)
 
 ### New features
@@ -108,3 +112,4 @@
 [@pocke]: https://github.com/pocke
 [@gyfis]: https:/github.com/gyfis
 [@DNA]: https://github.com/DNA
+[@ngouy]: https://github.com/ngouy

--- a/lib/rubocop/cop/rails/enum_hash.rb
+++ b/lib/rubocop/cop/rails/enum_hash.rb
@@ -42,7 +42,7 @@ module RuboCop
 
         def autocorrect(node)
           hash = node.children.each_with_index.map do |elem, index|
-            "#{elem.source} => #{index}"
+            "#{source(elem)} => #{index}"
           end.join(', ')
 
           ->(corrector) { corrector.replace(node.loc.expression, "{#{hash}}") }
@@ -56,6 +56,17 @@ module RuboCop
             key.value
           else
             key.source
+          end
+        end
+
+        def source(elem)
+          case elem.type
+          when :str
+            elem.value.dump
+          when :sym
+            elem.value.inspect
+          else
+            elem.source
           end
         end
       end

--- a/spec/rubocop/cop/rails/enum_hash_spec.rb
+++ b/spec/rubocop/cop/rails/enum_hash_spec.rb
@@ -112,6 +112,50 @@ RSpec.describe RuboCop::Cop::Rails::EnumHash do
         enum status: {STATUS::OLD => 0, STATUS::ACTIVE => 1}
       RUBY
     end
+
+    it 'autocorrects %w[] syntax' do
+      expect_offense(<<~RUBY)
+        enum status: %w[active archived]
+                     ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        enum status: {"active" => 0, "archived" => 1}
+      RUBY
+    end
+
+    it 'autocorrect %w() syntax' do
+      expect_offense(<<~RUBY)
+        enum status: %w(active archived)
+                     ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        enum status: {"active" => 0, "archived" => 1}
+      RUBY
+    end
+
+    it 'autocorrect %i[] syntax' do
+      expect_offense(<<~RUBY)
+        enum status: %i[active archived]
+                     ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        enum status: {:active => 0, :archived => 1}
+      RUBY
+    end
+
+    it 'autocorrect %i() syntax' do
+      expect_offense(<<~RUBY)
+        enum status: %i(active archived)
+                     ^^^^^^^^^^^^^^^^^^^ Enum defined as an array found in `status` enum declaration. Use hash syntax instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        enum status: {:active => 0, :archived => 1}
+      RUBY
+    end
   end
 
   context 'when hash syntax is used' do


### PR DESCRIPTION
update code and tests so autocorrect for enum hash handle % array notations such as 
`%w[done todo archived]` are well corrected

