### PR TITLE
Workaround for broke CI with YARD 0.9.20

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,4 +12,7 @@ gem 'rspec'
 gem 'rubocop', github: 'rubocop-hq/rubocop'
 gem 'rubocop-performance', '~> 1.5.0'
 gem 'rubocop-rspec', '~> 1.29.0'
-gem 'yard', '~> 0.9'
+# Workaround for YARD 0.9.20 or lower.
+# It specifies `github` until the release that includes the following changes:
+# https://github.com/lsegal/yard/pull/1290
+gem 'yard', github: 'lsegal/yard', ref: '10a2e5b'


### PR DESCRIPTION
This PR solves the following "The manual directory is out of sync" error.

```console
% ruby -v
ruby 2.7.0dev (2019-12-03T05:51:14Z master e42d9d8df8) [x86_64-darwin17]
% CI=true bundle exec rake

(snip)

The manual directory is out of sync. Run `rake
generate_cops_documentation` and commit the results.
```

https://circleci.com/gh/rubocop-hq/rubocop-rails/2180

This issue will be resolved with the release of YARD 0.9.21 or higher, which includes the following changes:
https://github.com/lsegal/yard/pull/1290

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
