### PR TITLE
Don't register BulkChangeTable offense if block intervenes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 
+* [#170](https://github.com/rubocop-hq/rubocop-rails/pull/170): Make `Rails/BulkChangeTable` not suggest combining methods with an intervening block. ([@mvz][])
 * [#159](https://github.com/rubocop-hq/rubocop-rails/issues/159): Fix autocorrect for `Rails/EnumHash` when using % arrays notations. ([@ngouy][])
 
 ## 2.4.0 (2019-11-27)
@@ -113,3 +114,4 @@
 [@gyfis]: https:/github.com/gyfis
 [@DNA]: https://github.com/DNA
 [@ngouy]: https://github.com/ngouy
+[@mvz]: https://github.com/mvz

--- a/lib/rubocop/cop/rails/bulk_change_table.rb
+++ b/lib/rubocop/cop/rails/bulk_change_table.rb
@@ -138,9 +138,9 @@ module RuboCop
 
           recorder = AlterMethodsRecorder.new
 
-          node.body.each_child_node(:send) do |send_node|
-            if combinable_alter_methods.include?(send_node.method_name)
-              recorder.process(send_node)
+          node.body.child_nodes.each do |child_node|
+            if call_to_combinable_alter_method? child_node
+              recorder.process(child_node)
             else
               recorder.flush
             end
@@ -216,6 +216,11 @@ module RuboCop
           else
             false
           end
+        end
+
+        def call_to_combinable_alter_method?(child_node)
+          child_node.send_type? &&
+            combinable_alter_methods.include?(child_node.method_name)
         end
 
         def combinable_alter_methods

--- a/spec/rubocop/cop/rails/bulk_change_table_spec.rb
+++ b/spec/rubocop/cop/rails/bulk_change_table_spec.rb
@@ -306,6 +306,18 @@ RSpec.describe RuboCop::Cop::Rails::BulkChangeTable, :config do
       RUBY
     end
 
+    it 'does not register an offense when including a block between' do
+      expect_no_offenses(<<~RUBY)
+        def change
+          add_column :users, :name, :string, null: false
+          User.find_each do |user|
+            user.update(name: user.nickname)
+          end
+          remove_column :users, :nickname
+        end
+      RUBY
+    end
+
     it 'does not register an offense' \
        'when including a combinable alter method' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**
The `Rails/BulkChangeTable` cop currently won't suggest combining table change method calls if there is another method call between them. However, this logic fails if the intervening call has a block, like so:

```ruby
add_column :users, :name, :string, null: false
User.find_each do |user|
  user.update(name: user.nick_name)
end
remove_column :users, :nickname
```

This pull request fixes that problem by looking at all of the method body's children, not just the `:send` nodes.

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
