### PR TITLE
Suppress a deprecation warning when using Ruby 2.7.0-dev

### DIFF
--- a/lib/rubocop/cop/rails/date.rb
+++ b/lib/rubocop/cop/rails/date.rb
@@ -84,13 +84,13 @@ module RuboCop
         private
 
         def check_deprecated_methods(node)
-          DEPRECATED_METHODS.each do |relevant:, deprecated:|
-            next unless node.method?(deprecated.to_sym)
+          DEPRECATED_METHODS.each do |method|
+            next unless node.method?(method[:deprecated].to_sym)
 
             add_offense(node, location: :selector,
                               message: format(DEPRECATED_MSG,
-                                              deprecated: deprecated,
-                                              relevant: relevant))
+                                              deprecated: method[:deprecated],
+                                              relevant: method[:relevant]))
           end
         end
 


### PR DESCRIPTION
This PR suppresses the following deprecation warning when using Ruby 2.7.0-dev.

```console
% ruby -v
ruby 2.7.0dev (2019-12-11T07:52:06Z master 3098798044) [x86_64-darwin17]

% bundle exec rake

(snip)

/Users/koic/src/github.com/rubocop-hq/rubocop-rails/lib/rubocop/cop/rails/date.rb:87:
warning: The last argument is used as the keyword parameter
/Users/koic/src/github.com/rubocop-hq/rubocop-rails/lib/rubocop/cop/rails/date.rb:87:
warning: for method defined here; maybe ** should be added to the call?
```

https://bugs.ruby-lang.org/issues/14183

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
