### PR TITLE
Move `LineLength` cop from `Metrics` to `Layout` department

### DIFF
--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe 'RuboCop Rails Project', type: :feature do
         it 'has a valid URL' do
           issues.each do |issue|
             number = issue[:number].gsub(/\D/, '')
-            pattern = %r{^https://github\.com/rubocop-hq/rubocop-rails/(?:issues|pull)/#{number}$} # rubocop:disable Metrics/LineLength
+            pattern = %r{^https://github\.com/rubocop-hq/rubocop-rails/(?:issues|pull)/#{number}$} # rubocop:disable Layout/LineLength
             expect(issue[:url]).to match(pattern)
           end
         end


### PR DESCRIPTION
Follow rubocop-hq/rubocop#7542.

This PR suppresses the following warning.

```console
% bundle exec rake
(snip)

Running RuboCop...
spec/project_spec.rb: Metrics/LineLength has the wrong namespace -
should be Layout
Inspecting 130 files
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
