### PR TITLE
Add another good example for RelativeDateConstant

### DIFF
--- a/lib/rubocop/cop/rails/relative_date_constant.rb
+++ b/lib/rubocop/cop/rails/relative_date_constant.rb
@@ -14,6 +14,15 @@ module RuboCop
       #
       #   # good
       #   class SomeClass
+      #     EXPIRES = 1.week
+      #
+      #     def self.expired_at
+      #       EXPIRES.since
+      #     end
+      #   end
+      #
+      #   # good
+      #   class SomeClass
       #     def self.expired_at
       #       1.week.since
       #     end

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -1902,6 +1902,15 @@ end
 
 # good
 class SomeClass
+  EXPIRES = 1.week
+
+  def self.expired_at
+    EXPIRES.since
+  end
+end
+
+# good
+class SomeClass
   def self.expired_at
     1.week.since
   end


### PR DESCRIPTION
The current good example seems to discourage the usage of a constant
completely. Add another good example to showcase how to continue using a
constant and have things working dynamically.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
