### PR TITLE
Rails.root.join is not a drop-in replacement.

### DIFF
--- a/lib/rubocop/cop/rails/file_path.rb
+++ b/lib/rubocop/cop/rails/file_path.rb
@@ -7,6 +7,9 @@ module RuboCop
       # to use `Rails.root.join` clause. It is used to add uniformity when
       # joining paths.
       #
+      # `Rails.root.join` is not a drop-in replacement. It returns a `Pathname`
+      # object which may require further changes to your code.
+      #
       # @example EnforcedStyle: arguments
       #   # bad
       #   Rails.root.join('app/models/goober')

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -818,6 +818,9 @@ This cop is used to identify usages of file path joining process
 to use `Rails.root.join` clause. It is used to add uniformity when
 joining paths.
 
+`Rails.root.join` is not a drop-in replacement. It returns a `Pathname`
+object which may require further changes to your code.
+
 ### Examples
 
 #### EnforcedStyle: arguments


### PR DESCRIPTION
I blindly replaced code like `Dir["#{Rails.root}/app/lib/foo/*.rb"].each` with `Rails.root.join("app/lib/foo/*.rb").each` which does not work. I needed `Rails.root.join("app/lib/foo/").glob("*.rb")`. A note about this gotcha in the documentation might help others.