### PR TITLE
Allow model associations to reference class_name: self.name

### DIFF
--- a/lib/rubocop/cop/rails/reflection_class_name.rb
+++ b/lib/rubocop/cop/rails/reflection_class_name.rb
@@ -3,8 +3,9 @@
 module RuboCop
   module Cop
     module Rails
-      # This cop checks if the value of the option `class_name`, in
-      # the definition of a reflection is a string.
+      # This cop checks the definition of model associations to only allow
+      # string values on the reflection option `class_name`, preventing
+      # the accidental autoloading of other model constants.
       #
       # @example
       #   # bad
@@ -13,6 +14,7 @@ module RuboCop
       #
       #   # good
       #   has_many :accounts, class_name: 'Account'
+      #   has_many :children, class_name: self.name
       class ReflectionClassName < Cop
         MSG = 'Use a string value for `class_name`.'
 
@@ -23,7 +25,7 @@ module RuboCop
         PATTERN
 
         def_node_matcher :reflection_class_name, <<~PATTERN
-          (pair (sym :class_name) [!dstr !str !sym])
+          (pair (sym :class_name) {const (send const ...)})
         PATTERN
 
         def on_send(node)

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -1841,8 +1841,9 @@ Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChan
 --- | --- | --- | --- | ---
 Enabled | Yes | No | 0.64 | -
 
-This cop checks if the value of the option `class_name`, in
-the definition of a reflection is a string.
+This cop checks the definition of model associations to only allow
+string values on the reflection option `class_name`, preventing
+the accidental autoloading of other model constants.
 
 ### Examples
 
@@ -1853,6 +1854,7 @@ has_many :accounts, class_name: Account.name
 
 # good
 has_many :accounts, class_name: 'Account'
+has_many :children, class_name: self.name
 ```
 
 ## Rails/RefuteMethods

--- a/spec/rubocop/cop/rails/reflection_class_name_spec.rb
+++ b/spec/rubocop/cop/rails/reflection_class_name_spec.rb
@@ -56,4 +56,20 @@ RSpec.describe RuboCop::Cop::Rails::ReflectionClassName do
       belongs_to :account, class_name: :Account
     RUBY
   end
+
+  it 'does not register an offense when using self.name for `class_name`' do
+    expect_no_offenses(<<~RUBY)
+      has_many :accounts, class_name: self.name, foreign_key: :account_id
+      has_one :account, class_name: self.name
+      belongs_to :account, class_name: self.name
+    RUBY
+  end
+
+  it 'does not register an offense when using own name for `class_name`' do
+    expect_no_offenses(<<~RUBY)
+      has_many :accounts, class_name: name, foreign_key: :account_id
+      has_one :account, class_name: name
+      belongs_to :account, class_name: name
+    RUBY
+  end
 end


### PR DESCRIPTION
When used in concern mixins, the class name that the association is included in
may be declared dynamically, instead of a static string.

This now only verifies that the `class_name:` option is not referencing a
constant, so other (dynamic) means of passing a string to the association
reflection can be supported.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
