### PR TITLE
[Fix #184] Fix Rake/Environment to allow task with no block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#184](https://github.com/rubocop-hq/rubocop-rails/issues/184): Fix `Rake/Environment` to allow task with no block. ([@hanachin][])
+
 ## 2.4.1 (2019-12-25)
 
 ### Bug fixes
@@ -122,3 +126,4 @@
 [@ngouy]: https://github.com/ngouy
 [@mvz]: https://github.com/mvz
 [@fidalgo]: https://github.com/fidalgo
+[@hanachin]: https://github.com/hanachin

--- a/lib/rubocop/cop/rails/rake_environment.rb
+++ b/lib/rubocop/cop/rails/rake_environment.rb
@@ -29,15 +29,16 @@ module RuboCop
         MSG = 'Include `:environment` task as a dependency for all Rake tasks.'
 
         def_node_matcher :task_definition?, <<~PATTERN
-          (send nil? :task ...)
+          (block $(send nil? :task ...) ...)
         PATTERN
 
-        def on_send(node)
-          return unless task_definition?(node)
-          return if task_name(node) == :default
-          return if with_dependencies?(node)
+        def on_block(node)
+          task_definition?(node) do |task_method|
+            return if task_name(task_method) == :default
+            return if with_dependencies?(task_method)
 
-          add_offense(node)
+            add_offense(task_method)
+          end
         end
 
         private

--- a/spec/rubocop/cop/rails/rake_environment_spec.rb
+++ b/spec/rubocop/cop/rails/rake_environment_spec.rb
@@ -83,4 +83,10 @@ RSpec.describe RuboCop::Cop::Rails::RakeEnvironment do
       task default: :spec
     RUBY
   end
+
+  it 'does not register an offense to task with no block' do
+    expect_no_offenses(<<~RUBY)
+      task(:foo).do_something
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #184 .

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
