### PR TITLE
Fix the issue that excluded files in rubocop-rails did not work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#184](https://github.com/rubocop-hq/rubocop-rails/issues/184): Fix `Rake/Environment` to allow task with no block. ([@hanachin][])
 * [#122](https://github.com/rubocop-hq/rubocop-rails/issues/122): Fix `Exclude` paths that were not inherited. ([@koic][])
+* [#187](https://github.com/rubocop-hq/rubocop-rails/pull/187): Fix an issue that excluded files in rubocop-rails did not work. ([@sinsoku][])
 
 ## 2.4.1 (2019-12-25)
 

--- a/lib/rubocop/rails/inject.rb
+++ b/lib/rubocop/rails/inject.rb
@@ -8,7 +8,7 @@ module RuboCop
       def self.defaults!
         path = CONFIG_DEFAULT.to_s
         hash = ConfigLoader.send(:load_yaml_configuration, path)
-        config = Config.new(hash, path)
+        config = Config.new(hash, path).tap(&:make_excludes_absolute)
         puts "configuration from #{path}" if ConfigLoader.debug?
         config = ConfigLoader.merge_with_default(config, path, unset_nil: false)
         ConfigLoader.instance_variable_set(:@default_configuration, config)

--- a/spec/rubocop/rails/inject_spec.rb
+++ b/spec/rubocop/rails/inject_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Rails::Inject do
+  describe '#defaults!' do
+    before { allow(Dir).to receive(:pwd).and_return('/home/foo/project') }
+
+    it 'makes excludes absolute' do
+      configuration = described_class.defaults!
+      expect(configuration['AllCops']['Exclude'])
+        .to include(
+          '/home/foo/project/bin/*',
+          '/home/foo/project/db/schema.rb'
+        )
+    end
+  end
+end


### PR DESCRIPTION
`bin/*` and `db/schema.rb` were not excluded.
Exclude files should be absolute paths internally, so it fixes to call the `make_excludes_absolute` method.

Ref: https://github.com/rubocop-hq/rubocop/commit/cb63798f6ae27c54db566a88e143bd5354095226

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
