### PR TITLE
[Fix #122] Fix `Exclude` paths that were not inherited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#184](https://github.com/rubocop-hq/rubocop-rails/issues/184): Fix `Rake/Environment` to allow task with no block. ([@hanachin][])
+* [#122](https://github.com/rubocop-hq/rubocop-rails/issues/122): Fix `Exclude` paths that were not inherited. ([@koic][])
 
 ## 2.4.1 (2019-12-25)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,5 +1,9 @@
 # Common configuration.
 
+inherit_mode:
+  merge:
+    - Exclude
+
 AllCops:
   Exclude:
     - bin/*


### PR DESCRIPTION
Fixes #122.

`Exclude` defined in RuboCop core was not inherited.
https://github.com/rubocop-hq/rubocop/blob/v0.79.0/config/default.yml#L60-L64

This PR fixes `Exclude` paths that were not inherited.
This bug was caused by #108.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
