### PR TITLE
[Fix #180] Fix a false positive for `HttpPositionalArguments`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#180](https://github.com/rubocop-hq/rubocop-rails/issues/180): Fix a false positive for `HttpPositionalArguments` when using `get` method with `:to` option. ([@koic][])
+
 ## 2.4.2 (2020-01-26)
 
 ### Bug fixes

--- a/lib/rubocop/cop/rails/http_positional_arguments.rb
+++ b/lib/rubocop/cop/rails/http_positional_arguments.rb
@@ -22,7 +22,7 @@ module RuboCop
         MSG = 'Use keyword arguments instead of ' \
               'positional arguments for http call: `%<verb>s`.'
         KEYWORD_ARGS = %i[
-          method params session body flash xhr as headers env
+          method params session body flash xhr as headers env to
         ].freeze
         HTTP_METHODS = %i[get post put patch delete head].freeze
 

--- a/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
+++ b/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
@@ -113,6 +113,12 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
       RUBY
     end
 
+    it 'registers an offense for get method with `:to` option' do
+      expect_no_offenses(<<~RUBY)
+        get '/test', to: 'admin/admin#test'
+      RUBY
+    end
+
     it 'registers an offense for post method' do
       expect_offense(<<~RUBY)
         post :create, user_id: @user.id


### PR DESCRIPTION
Fixes #180

This PR fixes a false positive for `HttpPositionalArguments` when using `get` method with `:to` option.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
