### PR TITLE
[Fix #200] Make SchemaLoader aware of Rails 5 expression index

### DIFF
--- a/lib/rubocop/rails/schema_loader/schema.rb
+++ b/lib/rubocop/rails/schema_loader/schema.rb
@@ -118,11 +118,11 @@ module RuboCop
 
       # Reprecent an index
       class Index
-        attr_reader :name, :columns, :unique
+        attr_reader :name, :columns, :expression, :unique
 
         def initialize(node)
           node.first_argument
-          @columns = build_columns(node)
+          @columns, @expression = build_columns_or_expr(node)
           @unique = nil
 
           analyze_keywords!(node)
@@ -130,8 +130,13 @@ module RuboCop
 
         private
 
-        def build_columns(node)
-          node.first_argument.values.map(&:value)
+        def build_columns_or_expr(node)
+          arg = node.first_argument
+          if arg.array_type?
+            [arg.values.map(&:value), nil]
+          else
+            [[], arg.value]
+          end
         end
 
         def analyze_keywords!(node)

--- a/spec/rubocop/rails/schema_loader_spec.rb
+++ b/spec/rubocop/rails/schema_loader_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe RuboCop::Rails::SchemaLoader do
           create_table "articles", force: :cascade do |t|
             t.string "title", null: false
             t.bigint "user_id"
+            t.index 'lower(title)', name: 'index_title_lower_unique', unique: true
           end
         end
       RUBY
@@ -76,6 +77,13 @@ RSpec.describe RuboCop::Rails::SchemaLoader do
 
           expect(table.columns.size).to eq 2
           expect(table.columns.last.type).to eq :bigint
+        end
+
+        it 'has an index in articles table' do
+          table = loaded_schema.table_by(name: 'articles')
+          expect(table.indices.size).to eq 1
+          expect(table.indices.first.name).to eq 'index_title_lower_unique'
+          expect(table.indices.first.unique).to be true
         end
       end
 


### PR DESCRIPTION
This pull request fixes #200 

The error occurred on Rails 5 expression index.



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
