### PR TITLE
# Address false positive when reversing remove_foreign_key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * [#180](https://github.com/rubocop-hq/rubocop-rails/issues/180): Fix a false positive for `HttpPositionalArguments` when using `get` method with `:to` option. ([@koic][])
 * [#193](https://github.com/rubocop-hq/rubocop-rails/issues/193): Make `Rails/EnvironmentComparison` aware of `Rails.env` is used in RHS or when `!=` is used for comparison. ([@koic][])
+* [#205](https://github.com/rubocop-hq/rubocop-rails/pull/205): Make `Rails/ReversibleMigration` aware of `:to_table` option of `remove_foreign_key`. ([@joshpencheon][])
 
 ## 2.4.2 (2020-01-26)
 
@@ -141,3 +142,4 @@
 [@mvz]: https://github.com/mvz
 [@fidalgo]: https://github.com/fidalgo
 [@hanachin]: https://github.com/hanachin
+[@joshpencheon]: https://github.com/joshpencheon

--- a/lib/rubocop/cop/rails/reversible_migration.rb
+++ b/lib/rubocop/cop/rails/reversible_migration.rb
@@ -90,6 +90,11 @@ module RuboCop
       #     remove_foreign_key :accounts, :branches
       #   end
       #
+      #   # good
+      #   def change
+      #     remove_foreign_key :accounts, to_table: :branches
+      #   end
+      #
       # @example
       #   # change_table
       #
@@ -210,7 +215,7 @@ module RuboCop
 
         def check_remove_foreign_key_node(node)
           remove_foreign_key_call(node) do |arg|
-            if arg.hash_type?
+            if arg.hash_type? && !all_hash_key?(arg, :to_table)
               add_offense(
                 node,
                 message: format(MSG,

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -2053,6 +2053,11 @@ end
 def change
   remove_foreign_key :accounts, :branches
 end
+
+# good
+def change
+  remove_foreign_key :accounts, to_table: :branches
+end
 ```
 ```ruby
 # change_table

--- a/spec/rubocop/cop/rails/reversible_migration_spec.rb
+++ b/spec/rubocop/cop/rails/reversible_migration_spec.rb
@@ -169,6 +169,10 @@ RSpec.describe RuboCop::Cop::Rails::ReversibleMigration, :config do
       remove_foreign_key :accounts, :branches
     RUBY
 
+    it_behaves_like 'accepts', 'remove_foreign_key(with :to_table)', <<~RUBY
+      remove_foreign_key :accounts, to_table: :branches
+    RUBY
+
     it_behaves_like 'offense', 'remove_foreign_key(without table)', <<~RUBY
       remove_foreign_key :accounts, column: :owner_id
     RUBY


### PR DESCRIPTION
The other table can be specified either as the second argument, or in the :to_table key of a hash as the second argument. The latter was not supported.

```ruby
# was bad, now good:
def change
  remove_foreign_key :accounts, to_table: :branches
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
