### PR TITLE
[Fix #206] Fix a false positive for `Rails/RakeEnvironment` when using Capistrano

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#180](https://github.com/rubocop-hq/rubocop-rails/issues/180): Fix a false positive for `HttpPositionalArguments` when using `get` method with `:to` option. ([@koic][])
 * [#193](https://github.com/rubocop-hq/rubocop-rails/issues/193): Make `Rails/EnvironmentComparison` aware of `Rails.env` is used in RHS or when `!=` is used for comparison. ([@koic][])
 * [#205](https://github.com/rubocop-hq/rubocop-rails/pull/205): Make `Rails/ReversibleMigration` aware of `:to_table` option of `remove_foreign_key`. ([@joshpencheon][])
+* [#207](https://github.com/rubocop-hq/rubocop-rails/pull/207): Fix a false positive for `Rails/RakeEnvironment` when using Capistrano. ([@sinsoku][])
 
 ## 2.4.2 (2020-01-26)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -346,6 +346,8 @@ Rails/RakeEnvironment:
   Include:
     - '**/Rakefile'
     - '**/*.rake'
+  Exclude:
+    - 'lib/capistrano/tasks/**/*.rake'
 
 Rails/ReadWriteAttribute:
   Description: >-

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -1696,6 +1696,7 @@ end
 Name | Default value | Configurable values
 --- | --- | ---
 Include | `**/Rakefile`, `**/*.rake` | Array
+Exclude | `lib/capistrano/tasks/**/*.rake` | Array
 
 ## Rails/ReadWriteAttribute
 


### PR DESCRIPTION
It excludes the directory where Capistrano tasks are located.
Because these tasks don't need to invoke the `:environment` task, and the directory structure is the official way.
ref: https://github.com/capistrano/capistrano/tree/v3.12.0#capify-your-project

Fixes #206

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
