### PR TITLE
Fix false positive for `UniqueValidationWithoutIndex` when using conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* Fix a false positive for `Rails/UniqueValidationWithoutIndex` when using conditions. ([@sunny][])
+
 ## 2.5.0 (2020-03-24)
 
 ### New features
@@ -149,3 +153,4 @@
 [@hanachin]: https://github.com/hanachin
 [@joshpencheon]: https://github.com/joshpencheon
 [@djudd]: https://github.com/djudd
+[@sunny]: https://github.com/sunny

--- a/lib/rubocop/cop/rails/unique_validation_without_index.rb
+++ b/lib/rubocop/cop/rails/unique_validation_without_index.rb
@@ -47,6 +47,8 @@ module RuboCop
           table = schema.table_by(name: table_name(klass))
           return true unless table # Skip analysis if it can't find the table
 
+          return true if condition_part?(node)
+
           names = column_names(node)
           return true unless names
 
@@ -110,6 +112,18 @@ module RuboCop
             next unless pair.key.sym_type? && pair.key.value == :uniqueness
 
             break pair.value
+          end
+        end
+
+        def condition_part?(node)
+          pairs = node.arguments.last
+          return unless pairs.hash_type?
+
+          pairs.each_pair.any? do |pair|
+            key = pair.key
+            next unless key.sym_type?
+
+            key.value == :if || key.value == :unless
           end
         end
 

--- a/spec/rubocop/cop/rails/unique_validation_without_index_spec.rb
+++ b/spec/rubocop/cop/rails/unique_validation_without_index_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe RuboCop::Cop::Rails::UniqueValidationWithoutIndex, :config do
         end
       RUBY
 
-      it 'registers no offense' do
+      it 'does not register an offense' do
         expect_no_offenses(<<~RUBY)
           class User
             validates :account, uniqueness: true
@@ -145,7 +145,7 @@ RSpec.describe RuboCop::Cop::Rails::UniqueValidationWithoutIndex, :config do
           end
         RUBY
 
-        it 'registers an offense' do
+        it 'does not register an offense' do
           expect_no_offenses(<<~RUBY)
             class WrittenArticles
               validates :user_id, uniqueness: { scope: :article_id }
@@ -192,7 +192,7 @@ RSpec.describe RuboCop::Cop::Rails::UniqueValidationWithoutIndex, :config do
           end
         RUBY
 
-        it 'registers an offense' do
+        it 'does not register an offense' do
           expect_no_offenses(<<~RUBY)
             class WrittenArticles
               validates :a_id, uniqueness: { scope: [:b_id, :c_id] }
@@ -234,11 +234,49 @@ RSpec.describe RuboCop::Cop::Rails::UniqueValidationWithoutIndex, :config do
           end
         RUBY
 
-        it 'does not register offense' do
+        it 'does not register an offense' do
           expect_no_offenses(<<~RUBY)
             class Article
               belongs_to :user
               validates :user, uniqueness: true
+            end
+          RUBY
+        end
+      end
+
+      context 'with an if condition on the validation' do
+        let(:schema) { <<~RUBY }
+          ActiveRecord::Schema.define(version: 2020_02_02_075409) do
+            create_table "articles", force: :cascade do |t|
+              t.bitint "user_id", null: false
+            end
+          end
+        RUBY
+
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            class Article
+              belongs_to :user
+              validates :user, uniqueness: true, if: -> { false }
+            end
+          RUBY
+        end
+      end
+
+      context 'with an unless condition on the validation' do
+        let(:schema) { <<~RUBY }
+          ActiveRecord::Schema.define(version: 2020_02_02_075409) do
+            create_table "articles", force: :cascade do |t|
+              t.bitint "user_id", null: false
+            end
+          end
+        RUBY
+
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            class Article
+              belongs_to :user
+              validates :user, uniqueness: true, unless: -> { true }
             end
           RUBY
         end
@@ -297,7 +335,7 @@ RSpec.describe RuboCop::Cop::Rails::UniqueValidationWithoutIndex, :config do
           end
         RUBY
 
-        it 'does not register offense' do
+        it 'does not register an offense' do
           expect_no_offenses(<<~RUBY)
             class Article
               belongs_to :member, foreign_key: :user_id


### PR DESCRIPTION
Hey everybody!

This fixes a false positive for `Rails/UniqueValidationWithoutIndex` when using conditions, such as:

```rb
class User < ApplicationRecord
  validates :email, uniqueness: true, unless: :guest?
end
```

--- 

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
