### PR TITLE
[Fix #215] Fix a false positive for `Rails/UniqueValidationWithoutIndex`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#213](https://github.com/rubocop-hq/rubocop-rails/pull/213): Fix a false positive for `Rails/UniqueValidationWithoutIndex` when using conditions. ([@sunny][])
+* [#215](https://github.com/rubocop-hq/rubocop-rails/issues/215): Fix a false positive for `Rails/UniqueValidationWithoutIndex` when using Expression Indexes. ([@koic][])
 
 ## 2.5.0 (2020-03-24)
 


### PR DESCRIPTION
Fixes #215.

This PR fixes a false positive for `Rails/UniqueValidationWithoutIndex` when using Expression Indexes for PostgreSQL.

Since it is difficult to predict a kind of string described in Expression Indexes, this implementation judges based on whether or not an Expression Indexes include a column name.
There is a possibility of false negative, but in most cases I expect it works.

## References

- https://www.postgresql.org/docs/12/indexes-expressional.html
- https://github.com/rails/rails/commit/edc2b7718725016e988089b5fb6d6fb9d6e16882

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
