### PR TITLE
[Fix #214] Fix an error for `Rails/UniqueValidationWithoutIndex`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#213](https://github.com/rubocop-hq/rubocop-rails/pull/213): Fix a false positive for `Rails/UniqueValidationWithoutIndex` when using conditions. ([@sunny][])
 * [#215](https://github.com/rubocop-hq/rubocop-rails/issues/215): Fix a false positive for `Rails/UniqueValidationWithoutIndex` when using Expression Indexes. ([@koic][])
+* [#214](https://github.com/rubocop-hq/rubocop-rails/issues/214): Fix an error for `Rails/UniqueValidationWithoutIndex`when a table has no column definition. ([@koic][])
 
 ## 2.5.0 (2020-03-24)
 

--- a/lib/rubocop/rails/schema_loader/schema.rb
+++ b/lib/rubocop/rails/schema_loader/schema.rb
@@ -60,7 +60,7 @@ module RuboCop
 
         def build_columns(node)
           each_content(node).map do |child|
-            next unless child.send_type?
+            next unless child&.send_type?
             next if child.method?(:index)
 
             Column.new(child)
@@ -69,7 +69,7 @@ module RuboCop
 
         def build_indices(node)
           each_content(node).map do |child|
-            next unless child.send_type?
+            next unless child&.send_type?
             next unless child.method?(:index)
 
             Index.new(child)
@@ -79,7 +79,7 @@ module RuboCop
         def each_content(node)
           return enum_for(__method__, node) unless block_given?
 
-          case node.body.type
+          case node.body&.type
           when :begin
             node.body.children.each do |child|
               yield(child)

--- a/spec/rubocop/cop/rails/unique_validation_without_index_spec.rb
+++ b/spec/rubocop/cop/rails/unique_validation_without_index_spec.rb
@@ -303,6 +303,23 @@ RSpec.describe RuboCop::Cop::Rails::UniqueValidationWithoutIndex, :config do
       end
     end
 
+    context 'when a table has no column definition' do
+      let(:schema) { <<~RUBY }
+        ActiveRecord::Schema.define(version: 2020_02_02_075409) do
+          create_table "users", force: :cascade do |t|
+          end
+        end
+      RUBY
+
+      it 'ignores it' do
+        expect_no_offenses(<<~RUBY)
+          class User
+            validates :account, uniqueness: true
+          end
+        RUBY
+      end
+    end
+
     context 'when the validation is for a relation with foreign_key: option' do
       context 'without proper index' do
         let(:schema) { <<~RUBY }


### PR DESCRIPTION
Fixes #214.

This PR fixes an error for `Rails/UniqueValidationWithoutIndex` when a table has no column definition.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
