### PR TITLE
[Fix #221] Make `Rails/UniqueValidationWithoutIndex` aware of `add_index`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#213](https://github.com/rubocop-hq/rubocop-rails/pull/213): Fix a false positive for `Rails/UniqueValidationWithoutIndex` when using conditions. ([@sunny][])
 * [#215](https://github.com/rubocop-hq/rubocop-rails/issues/215): Fix a false positive for `Rails/UniqueValidationWithoutIndex` when using Expression Indexes. ([@koic][])
 * [#214](https://github.com/rubocop-hq/rubocop-rails/issues/214): Fix an error for `Rails/UniqueValidationWithoutIndex`when a table has no column definition. ([@koic][])
+* [#221](https://github.com/rubocop-hq/rubocop-rails/issues/221): Make `Rails/UniqueValidationWithoutIndex` aware of `add_index` in db/schema.rb. ([@koic][])
 
 ## 2.5.0 (2020-03-24)
 

--- a/lib/rubocop/cop/rails/unique_validation_without_index.rb
+++ b/lib/rubocop/cop/rails/unique_validation_without_index.rb
@@ -51,7 +51,10 @@ module RuboCop
           names = column_names(node)
           return true unless names
 
-          table.indices.any? do |index|
+          # Compatibility for Rails 4.2.
+          add_indicies = schema.add_indicies_by(table_name: table_name(klass))
+
+          (table.indices + add_indicies).any? do |index|
             index.unique &&
               (index.columns.to_set == names ||
                include_column_names_in_expression_index?(index, names))


### PR DESCRIPTION
Fixes #221.

This PR makes `Rails/UniqueValidationWithoutIndex` aware of `add_index` in db/schema.rb.

Rails 4.0 and Rails 4.1 support will drop shortly, but Rails 4.2 may be a bit ahead. There may be changes to these support after the bug fix release of RoboCop Rails 2.5 series.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
