### PR TITLE
Mark `Rails/ApplicationController` and similar cops as unsafe autocorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 * [#214](https://github.com/rubocop-hq/rubocop-rails/issues/214): Fix an error for `Rails/UniqueValidationWithoutIndex`when a table has no column definition. ([@koic][])
 * [#221](https://github.com/rubocop-hq/rubocop-rails/issues/221): Make `Rails/UniqueValidationWithoutIndex` aware of `add_index` in db/schema.rb. ([@koic][])
 
+### Changes
+
+* [#223](https://github.com/rubocop-hq/rubocop-rails/pull/223): Mark `Rails/ApplicationController`, `Rails/ApplicationJob`, `Rails/ApplicationMailer`, and `Rails/ApplicationRecord` as unsafe autocorrect. ([@hoshinotsuyoshi][])
+
 ## 2.5.0 (2020-03-24)
 
 ### New features
@@ -157,3 +161,4 @@
 [@joshpencheon]: https://github.com/joshpencheon
 [@djudd]: https://github.com/djudd
 [@sunny]: https://github.com/sunny
+[@hoshinotsuyoshi]: https://github.com/hoshinotsuyoshi

--- a/config/default.yml
+++ b/config/default.yml
@@ -57,22 +57,30 @@ Rails/ActiveSupportAliases:
 Rails/ApplicationController:
   Description: 'Check that controllers subclass ApplicationController.'
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '2.4'
+  VersionChanged: '2.5'
 
 Rails/ApplicationJob:
   Description: 'Check that jobs subclass ApplicationJob.'
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '0.49'
+  VersionChanged: '2.5'
 
 Rails/ApplicationMailer:
   Description: 'Check that mailers subclass ApplicationMailer.'
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '2.4'
+  VersionChanged: '2.5'
 
 Rails/ApplicationRecord:
   Description: 'Check that models subclass ApplicationRecord.'
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '0.49'
+  VersionChanged: '2.5'
 
 Rails/AssertNot:
   Description: 'Use `assert_not` instead of `assert !`.'

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -131,7 +131,7 @@ are not used.
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 2.4 | -
+Enabled | Yes | Yes (Unsafe) | 2.4 | 2.5
 
 This cop checks that controllers subclass ApplicationController.
 
@@ -153,7 +153,7 @@ end
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 0.49 | -
+Enabled | Yes | Yes (Unsafe) | 0.49 | 2.5
 
 This cop checks that jobs subclass ApplicationJob with Rails 5.0.
 
@@ -175,7 +175,7 @@ end
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 2.4 | -
+Enabled | Yes | Yes (Unsafe) | 2.4 | 2.5
 
 This cop checks that mailers subclass ApplicationMailer with Rails 5.0.
 
@@ -197,7 +197,7 @@ end
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 0.49 | -
+Enabled | Yes | Yes (Unsafe) | 0.49 | 2.5
 
 This cop checks that models subclass ApplicationRecord with Rails 5.0.
 


### PR DESCRIPTION

We have a controller class which inherits `ActionController::Base` directly.
That controller is for health check endpoint.

```ruby
class HealthCheckController < ActionController::Base
  # we want to skip some authentication logics...
  def index
    head :ok
  end
end
```

```ruby
class ApplicationController < ActionController::Base
  # default some authentication logics...
end
```

In such case, automatically modifying the `ActionController :: Base`->` ApplicationController` is not safe .


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
