### PR TITLE
[Fix #210] Change enforced style to conditionals for `Style/AndOr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 * [#233](https://github.com/rubocop-hq/rubocop-rails/pull/233): **(BREAKING)** Drop support for Ruby 2.3. ([@koic][])
 * [#236](https://github.com/rubocop-hq/rubocop-rails/pull/236): **(BREAKING)** Drop support for Rails 4.1 or lower. ([@koic][])
+* [#210](https://github.com/rubocop-hq/rubocop-rails/issues/210): Accept `redirecto_to(...) and return` and similar cases. ([@koic][])
 
 ## 2.5.2 (2020-04-09)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -549,3 +549,7 @@ Rails/Validation:
   VersionChanged: '0.41'
   Include:
     - app/models/**/*.rb
+
+# Accept `redirecto_to(...) and return` and similar cases.
+Style/AndOr:
+  EnforcedStyle: conditionals


### PR DESCRIPTION
Resolves #210.

The following idioms exist for `return` and` raise` in Ruby.

- `do_something and return`
- `do_something || raise`

And Rails will also show users the error message using this idiom.

> `"redirect_to(...) and return\"`

https://github.com/rails/rails/blob/v6.0.2.2/actionpack/lib/abstract_controller/rendering.rb#L10

This is the same for `render :action and return` and others.

`Style/AndOr` cop default rule (`EnforcedStyle: always`) does seem to unmatch for these cases. I think these cases need to be accepted.

So, this PR changes it to `EnforcedStyle: conditionals` at least in Rails. The enforced style cannot catch all cases, but probably the closest to solving the issue.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
