### PR TITLE
[Fix #227] Make `Rails/UniqueValidationWithoutIndex` aware of updating schema.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#227](https://github.com/rubocop-hq/rubocop-rails/issues/227): Make `Rails/UniqueValidationWithoutIndex` aware of updating db/schema.rb. ([@koic][])
+
 ## 2.5.1 (2020-04-02)
 
 ### Bug fixes

--- a/lib/rubocop/cop/mixin/active_record_helper.rb
+++ b/lib/rubocop/cop/mixin/active_record_helper.rb
@@ -14,6 +14,23 @@ module RuboCop
         (send nil? :belongs_to {str sym} ...)
       PATTERN
 
+      def external_dependency_checksum
+        if defined?(@external_dependency_checksum)
+          return @external_dependency_checksum
+        end
+
+        schema_path = RuboCop::Rails::SchemaLoader.db_schema_path
+        return nil if schema_path.nil?
+
+        schema_code = File.read(schema_path)
+
+        @external_dependency_checksum ||= Digest::SHA1.hexdigest(schema_code)
+      end
+
+      def schema
+        RuboCop::Rails::SchemaLoader.load(target_ruby_version)
+      end
+
       def table_name(class_node)
         table_name = find_set_table_name(class_node).to_a.last&.first_argument
         return table_name.value.to_s if table_name

--- a/lib/rubocop/cop/rails/unique_validation_without_index.rb
+++ b/lib/rubocop/cop/rails/unique_validation_without_index.rb
@@ -149,10 +149,6 @@ module RuboCop
             end
           end
         end
-
-        def schema
-          RuboCop::Rails::SchemaLoader.load(target_ruby_version)
-        end
       end
     end
   end

--- a/lib/rubocop/rails/schema_loader.rb
+++ b/lib/rubocop/rails/schema_loader.rb
@@ -24,16 +24,6 @@ module RuboCop
         remove_instance_variable(:@schema)
       end
 
-      private
-
-      def load!(target_ruby_version)
-        path = db_schema_path
-        return unless path
-
-        ast = parse(path, target_ruby_version)
-        Schema.new(ast)
-      end
-
       def db_schema_path
         path = Pathname.pwd
         until path.root?
@@ -44,6 +34,16 @@ module RuboCop
         end
 
         nil
+      end
+
+      private
+
+      def load!(target_ruby_version)
+        path = db_schema_path
+        return unless path
+
+        ast = parse(path, target_ruby_version)
+        Schema.new(ast)
       end
 
       def parse(path, target_ruby_version)

--- a/spec/rubocop/cop/active_record_helper_spec.rb
+++ b/spec/rubocop/cop/active_record_helper_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::ActiveRecordHelper, :isolated_environment do
+  include FileHelper
+
+  module RuboCop
+    module Cop
+      class Example < Cop
+        include ActiveRecordHelper
+      end
+    end
+  end
+
+  let(:cop) do
+    RuboCop::Cop::Example.new
+  end
+
+  let(:schema_path) { 'db/schema.rb' }
+
+  describe '#external_dependency_checksum' do
+    subject { cop.external_dependency_checksum }
+
+    context 'with db/schema.rb' do
+      before do
+        create_file(schema_path, <<~RUBY)
+          ActiveRecord::Schema.define(version: 2020_04_08_082625) do
+            create_table "articles" do |t|
+              t.string "title", null: false
+            end
+          end
+        RUBY
+      end
+
+      it { is_expected.to eq '1f263bed5ada8f2292ce7ceebd3c518bac3d2d1d' }
+    end
+
+    context 'with empty db/schema.rb' do
+      before { create_empty_file(schema_path) }
+
+      it { is_expected.to eq 'adc83b19e793491b1c6ea0fd8b46cd9f32e592fc' }
+    end
+
+    context 'without db/schema.rb' do
+      it { is_expected.to be_nil }
+    end
+  end
+end


### PR DESCRIPTION
Fixes #227.

This PR makes `Rails/UniqueValidationWithoutIndex` aware of updating db/schema.rb

`Rails/UniqueValidationWithoutIndex` cop needs to know both model and db/schema.rb changes to register an offense. However, with default RuboCop, only changes to the model affect cache behavior.

This PR ensures that changes to db/schema.rb affect the cache by overriding the following method:

```ruby
# This method should be overridden when a cop's behavior depends
# on state that lives outside of these locations:
#
#   (1) the file under inspection
#   (2) the cop's source code
#   (3) the config (eg a .rubocop.yml file)
#
# For example, some cops may want to look at other parts of
# the codebase being inspected to find violations. A cop may
# use the presence or absence of file `foo.rb` to determine
# whether a certain violation exists in `bar.rb`.
#
# Overriding this method allows the cop to indicate to RuboCop's
# ResultCache system when those external dependencies change,
# ie when the ResultCache should be invalidated.
def external_dependency_checksum
  nil
end
```

https://github.com/rubocop-hq/rubocop/blob/v0.81.0/lib/rubocop/cop/cop.rb#L222-L239

See for more details: https://github.com/rubocop-hq/rubocop/pull/7496

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
