### PR TITLE
[Fix #12] Allow passing boolean literals to touch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#12](https://github.com/rubocop-hq/rubocop-rails/issues/12): Fix a false positive for `Rails/SkipsModelValidations` when passing a boolean literal to `touch`. ([@eugeneius][])
+
 ## 2.5.2 (2020-04-09)
 
 ### Bug fixes

--- a/lib/rubocop/cop/rails/skips_model_validations.rb
+++ b/lib/rubocop/cop/rails/skips_model_validations.rb
@@ -50,7 +50,10 @@ module RuboCop
                                     update_counters].freeze
 
         def_node_matcher :good_touch?, <<~PATTERN
-          (send (const nil? :FileUtils) :touch ...)
+          {
+            (send (const nil? :FileUtils) :touch ...)
+            (send _ :touch {true false})
+          }
         PATTERN
 
         def on_send(node)

--- a/spec/rubocop/cop/rails/skips_model_validations_spec.rb
+++ b/spec/rubocop/cop/rails/skips_model_validations_spec.rb
@@ -35,6 +35,14 @@ RSpec.describe RuboCop::Cop::Rails::SkipsModelValidations, :config do
     it 'accepts FileUtils.touch' do
       expect_no_offenses("FileUtils.touch('file')")
     end
+
+    it 'accepts touch with literal true' do
+      expect_no_offenses('belongs_to(:user).touch(true)')
+    end
+
+    it 'accepts touch with literal false' do
+      expect_no_offenses('belongs_to(:user).touch(false)')
+    end
   end
 
   context 'with methods that require at least an argument' do


### PR DESCRIPTION
Fixes https://github.com/rubocop-hq/rubocop-rails/issues/12.

The `Rails/SkipsModelValidations` cop currently incorrectly registers an offense for the `touch` method from Shoulda Matchers' associations DSL:

```ruby
it { is_expected.to belong_to(:user).touch(true) }
```

Active Record's `touch` method accepts attribute names, so we can treat `touch` calls that pass boolean literal arguments as false positives.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/