### PR TITLE
Drop support for Ruby 2.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,6 @@ workflows:
   build:
     jobs:
       - rake_default:
-          name: Ruby 2.3
-          image: circleci/ruby:2.3
-      - rake_default:
           name: Ruby 2.4
           image: circleci/ruby:2.4
       - rake_default:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,7 @@ AllCops:
     - 'vendor/**/*'
     - 'spec/fixtures/**/*'
     - 'tmp/**/*'
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
 
 Naming/PredicateName:
   # Method define macros for dynamically generated method.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#12](https://github.com/rubocop-hq/rubocop-rails/issues/12): Fix a false positive for `Rails/SkipsModelValidations` when passing a boolean literal to `touch`. ([@eugeneius][])
 
+### Changes
+
+* [#233](https://github.com/rubocop-hq/rubocop-rails/pull/233): **(BREAKING)** Drop support for Ruby 2.3. ([@koic][])
+
 ## 2.5.2 (2020-04-09)
 
 ### Bug fixes

--- a/rubocop-rails.gemspec
+++ b/rubocop-rails.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.name = 'rubocop-rails'
   s.version = RuboCop::Rails::Version::STRING
   s.platform = Gem::Platform::RUBY
-  s.required_ruby_version = '>= 2.3.0'
+  s.required_ruby_version = '>= 2.4.0'
   s.authors = ['Bozhidar Batsov', 'Jonas Arvidsson', 'Yuji Nakayama']
   s.description = <<~DESCRIPTION
     Automatic Rails code style checking tool.


### PR DESCRIPTION
Follow rubocop-hq/rubocop#7869.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
