### PR TITLE
Add autocorrect to `Rails/RakeEnvironment` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * [#51](https://github.com/rubocop-hq/rubocop-rails/issues/51): Add allowed receiver class names option for `Rails/DynamicFindBy`. ([@tejasbubane][])
+* [#211](https://github.com/rubocop-hq/rubocop-rails/issues/211): Add autocorrect to `Rails/RakeEnvironment` cop. ([@tejasbubane][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -367,6 +367,7 @@ Rails/RakeEnvironment:
   Enabled: true
   Safe: false
   VersionAdded: '2.4'
+  VersionChanged: '2.6'
   Include:
     - '**/Rakefile'
     - '**/*.rake'

--- a/lib/rubocop/cop/rails/rake_environment.rb
+++ b/lib/rubocop/cop/rails/rake_environment.rb
@@ -41,7 +41,24 @@ module RuboCop
           end
         end
 
+        def autocorrect(node)
+          lambda do |corrector|
+            task_name = node.arguments[0]
+            task_dependency = correct_task_dependency(task_name)
+
+            corrector.replace(task_name.loc.expression, task_dependency)
+          end
+        end
+
         private
+
+        def correct_task_dependency(task_name)
+          if task_name.sym_type?
+            task_name.source.delete(':|\'|"') + ': :environment'
+          else
+            "#{task_name.source} => :environment"
+          end
+        end
 
         def task_name(node)
           first_arg = node.arguments[0]

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -1722,7 +1722,7 @@ UnlessBlank | `true` | Boolean
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | No | No | 2.4 | -
+Enabled | No | Yes  | 2.4 | 2.6
 
 This cop checks for Rake tasks without the `:environment` task
 dependency. The `:environment` task loads application code for other

--- a/spec/rubocop/cop/rails/rake_environment_spec.rb
+++ b/spec/rubocop/cop/rails/rake_environment_spec.rb
@@ -11,6 +11,37 @@ RSpec.describe RuboCop::Cop::Rails::RakeEnvironment do
       ^^^^^^^^^ Include `:environment` task as a dependency for all Rake tasks.
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      task foo: :environment do
+      end
+    RUBY
+  end
+
+  it 'registers an offense for string task name' do
+    expect_offense(<<~RUBY)
+      task 'bar' do
+      ^^^^^^^^^^ Include `:environment` task as a dependency for all Rake tasks.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      task 'bar' => :environment do
+      end
+    RUBY
+  end
+
+  it 'registers an offense for namespaced task name' do
+    expect_offense(<<~RUBY)
+      task 'foo:bar:baz' do
+      ^^^^^^^^^^^^^^^^^^ Include `:environment` task as a dependency for all Rake tasks.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      task 'foo:bar:baz' => :environment do
+      end
+    RUBY
   end
 
   it 'does not register an offense to task with :environment ' \
@@ -87,6 +118,12 @@ RSpec.describe RuboCop::Cop::Rails::RakeEnvironment do
   it 'does not register an offense to task with no block' do
     expect_no_offenses(<<~RUBY)
       task(:foo).do_something
+    RUBY
+  end
+
+  it 'does not register an offense to task with string name and arguments' do
+    expect_no_offenses(<<~RUBY)
+      task 'foo' => [dep, :bar]
     RUBY
   end
 end


### PR DESCRIPTION
Closes #211

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/