### PR TITLE
Drop support for Rails 4.1 or lower

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changes
 
 * [#233](https://github.com/rubocop-hq/rubocop-rails/pull/233): **(BREAKING)** Drop support for Ruby 2.3. ([@koic][])
+* [#236](https://github.com/rubocop-hq/rubocop-rails/pull/236): **(BREAKING)** Drop support for Rails 4.1 or lower. ([@koic][])
 
 ## 2.5.2 (2020-04-09)
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ You can read a lot more about RuboCop Rails in its [official docs](https://docs.
 
 Rails cops support the following versions:
 
-- Rails 4.0+
+- Rails 4.2+
 
 ## Contributing
 

--- a/lib/rubocop/cop/rails/http_positional_arguments.rb
+++ b/lib/rubocop/cop/rails/http_positional_arguments.rb
@@ -8,7 +8,7 @@ module RuboCop
       # change them to use keyword args. This cop only applies to Rails >= 5.
       # If you are running Rails < 5 you should disable the
       # Rails/HttpPositionalArguments cop or set your TargetRailsVersion in your
-      # .rubocop.yml file to 4.0, etc.
+      # .rubocop.yml file to 4.2.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/rails/inverse_of.rb
+++ b/lib/rubocop/cop/rails/inverse_of.rb
@@ -129,10 +129,6 @@ module RuboCop
       # @see https://guides.rubyonrails.org/association_basics.html#bi-directional-associations
       # @see https://api.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html#module-ActiveRecord::Associations::ClassMethods-label-Setting+Inverses
       class InverseOf < Cop
-        extend TargetRailsVersion
-
-        minimum_target_rails_version 4.1
-
         SPECIFY_MSG = 'Specify an `:inverse_of` option.'
         NIL_MSG = 'You specified `inverse_of: nil`, you probably meant to ' \
           'use `inverse_of: false`.'

--- a/lib/rubocop/cop/rails/redundant_receiver_in_with_options.rb
+++ b/lib/rubocop/cop/rails/redundant_receiver_in_with_options.rb
@@ -55,10 +55,7 @@ module RuboCop
       #     end
       #   end
       class RedundantReceiverInWithOptions < Cop
-        extend TargetRailsVersion
         include RangeHelp
-
-        minimum_target_rails_version 4.2
 
         MSG = 'Redundant receiver in `with_options`.'
 

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -1020,7 +1020,7 @@ This cop is used to identify usages of http methods like `get`, `post`,
 change them to use keyword args. This cop only applies to Rails >= 5.
 If you are running Rails < 5 you should disable the
 Rails/HttpPositionalArguments cop or set your TargetRailsVersion in your
-.rubocop.yml file to 4.0, etc.
+.rubocop.yml file to 4.2.
 
 ### Examples
 

--- a/rubocop-rails.gemspec
+++ b/rubocop-rails.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
     'bug_tracker_uri' => 'https://github.com/rubocop-hq/rubocop-rails/issues'
   }
 
-  s.add_runtime_dependency 'activesupport'
+  s.add_runtime_dependency 'activesupport', '>= 4.2.0'
   # Rack::Utils::SYMBOL_TO_STATUS_CODE, which is used by HttpStatus cop, was
   # introduced in rack 1.1
   s.add_runtime_dependency 'rack', '>= 1.1'

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe RuboCop::Config do
       end
 
       context 'correctly' do
-        let(:rails_version) { 4.0 }
+        let(:rails_version) { 6.0 }
 
         it 'uses TargetRailsVersion' do
           expect(configuration.target_rails_version).to eq rails_version

--- a/spec/rubocop/cop/rails/redundant_receiver_in_with_options_spec.rb
+++ b/spec/rubocop/cop/rails/redundant_receiver_in_with_options_spec.rb
@@ -3,110 +3,92 @@
 RSpec.describe RuboCop::Cop::Rails::RedundantReceiverInWithOptions, :config do
   subject(:cop) { described_class.new(config) }
 
-  context 'Rails >= 4.2', :rails42 do
-    it 'registers an offense and corrects using explicit receiver ' \
+  it 'registers an offense and corrects using explicit receiver ' \
       'in `with_options`' do
-      expect_offense(<<~RUBY)
-        class Account < ApplicationRecord
-          with_options dependent: :destroy do |assoc|
-            assoc.has_many :customers
-            ^^^^^ Redundant receiver in `with_options`.
-            assoc.has_many :products
-            ^^^^^ Redundant receiver in `with_options`.
-            assoc.has_many :invoices
-            ^^^^^ Redundant receiver in `with_options`.
-            assoc.has_many :expenses
-            ^^^^^ Redundant receiver in `with_options`.
-          end
+    expect_offense(<<~RUBY)
+      class Account < ApplicationRecord
+        with_options dependent: :destroy do |assoc|
+          assoc.has_many :customers
+          ^^^^^ Redundant receiver in `with_options`.
+          assoc.has_many :products
+          ^^^^^ Redundant receiver in `with_options`.
+          assoc.has_many :invoices
+          ^^^^^ Redundant receiver in `with_options`.
+          assoc.has_many :expenses
+          ^^^^^ Redundant receiver in `with_options`.
         end
-      RUBY
+      end
+    RUBY
 
-      expect_correction(<<~RUBY)
-        class Account < ApplicationRecord
-          with_options dependent: :destroy do
-            has_many :customers
-            has_many :products
-            has_many :invoices
-            has_many :expenses
-          end
+    expect_correction(<<~RUBY)
+      class Account < ApplicationRecord
+        with_options dependent: :destroy do
+          has_many :customers
+          has_many :products
+          has_many :invoices
+          has_many :expenses
         end
-      RUBY
-    end
-
-    it 'does not register an offense when using inplicit receiver ' \
-       'in `with_options`' do
-      expect_no_offenses(<<~RUBY)
-        class Account < ApplicationRecord
-          with_options dependent: :destroy do
-            has_many :customers
-            has_many :products
-            has_many :invoices
-            has_many :expenses
-          end
-        end
-      RUBY
-    end
-
-    it 'registers an offense and corrects when including multiple ' \
-      'redendant receivers in single line' do
-      expect_offense(<<~RUBY)
-        with_options options: false do |merger|
-          merger.invoke(merger.something)
-          ^^^^^^ Redundant receiver in `with_options`.
-                        ^^^^^^ Redundant receiver in `with_options`.
-        end
-      RUBY
-
-      expect_correction(<<~RUBY)
-        with_options options: false do
-          invoke(something)
-        end
-      RUBY
-    end
-
-    it 'does not register an offense when including method invocations ' \
-       'to different receivers' do
-      expect_no_offenses(<<~RUBY)
-        client = ApplicationClient.new
-        with_options options: false do |merger|
-          client.invoke(merger.something, something)
-        end
-      RUBY
-    end
-
-    it 'does not register an offense when including block node' \
-       'in `with_options`' do
-      expect_no_offenses(<<~RUBY)
-        with_options options: false do |merger|
-          merger.invoke
-          with_another_method do |another_receiver|
-            merger.invoke(another_receiver)
-          end
-        end
-      RUBY
-    end
-
-    it 'does not register an offense when empty' do
-      expect_no_offenses(<<~RUBY)
-        with_options options: false do |merger|
-        end
-      RUBY
-    end
+      end
+    RUBY
   end
 
-  context 'Rails <= 4.1', :rails41 do
-    it 'does not register an offense when using explicit receiver in ' \
-       '`with_options`' do
-      expect_no_offenses(<<~RUBY)
-        class Account < ApplicationRecord
-          with_options dependent: :destroy do |assoc|
-            assoc.has_many :customers
-            assoc.has_many :products
-            assoc.has_many :invoices
-            assoc.has_many :expenses
-          end
+  it 'does not register an offense when using inplicit receiver ' \
+     'in `with_options`' do
+    expect_no_offenses(<<~RUBY)
+      class Account < ApplicationRecord
+        with_options dependent: :destroy do
+          has_many :customers
+          has_many :products
+          has_many :invoices
+          has_many :expenses
         end
-      RUBY
-    end
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects when including multiple ' \
+     'redendant receivers in single line' do
+    expect_offense(<<~RUBY)
+      with_options options: false do |merger|
+        merger.invoke(merger.something)
+        ^^^^^^ Redundant receiver in `with_options`.
+                      ^^^^^^ Redundant receiver in `with_options`.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      with_options options: false do
+        invoke(something)
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when including method invocations ' \
+     'to different receivers' do
+    expect_no_offenses(<<~RUBY)
+      client = ApplicationClient.new
+      with_options options: false do |merger|
+        client.invoke(merger.something, something)
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when including block node' \
+     'in `with_options`' do
+    expect_no_offenses(<<~RUBY)
+      with_options options: false do |merger|
+        merger.invoke
+        with_another_method do |another_receiver|
+          merger.invoke(another_receiver)
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when empty' do
+    expect_no_offenses(<<~RUBY)
+      with_options options: false do |merger|
+      end
+    RUBY
   end
 end

--- a/spec/support/shared_contexts.rb
+++ b/spec/support/shared_contexts.rb
@@ -1,13 +1,5 @@
 # frozen_string_literal: true
 
-RSpec.shared_context 'with Rails 4.0', :rails40 do
-  let(:rails_version) { 4.0 }
-end
-
-RSpec.shared_context 'with Rails 4.1', :rails41 do
-  let(:rails_version) { 4.1 }
-end
-
 RSpec.shared_context 'with Rails 4.2', :rails42 do
   let(:rails_version) { 4.2 }
 end


### PR DESCRIPTION
Follow up to #222.

This PR drops support for Rails 4.1 or lower.

RuboCop Rails 2.6 will drop support for Rails 4.1 or lower. Maybe RuboCop Rails 3.0 will drop Rails 4 series support in future. RuboCop Rails is currently negative support for Rails 4 series, and new features for Rails 4 will basically not be accepted.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
