### PR TITLE
Fixes Rails/IndexBy correction when .to_h is separated by a newline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug fixes
 
 * [#12](https://github.com/rubocop-hq/rubocop-rails/issues/12): Fix a false positive for `Rails/SkipsModelValidations` when passing a boolean literal to `touch`. ([@eugeneius][])
+* [#238](https://github.com/rubocop-hq/rubocop-rails/issues/238): Fix auto correction for `Rails/IndexBy` when the `.to_h` invocation is separated in multiple lines. ([@diogoosorio][])
 
 ### Changes
 
@@ -183,3 +184,4 @@
 [@sunny]: https://github.com/sunny
 [@hoshinotsuyoshi]: https://github.com/hoshinotsuyoshi
 [@tejasbubane]: https://github.com/tejasbubane
+[@diogoosorio]: https://github.com/diogoosorio

--- a/lib/rubocop/cop/mixin/index_method.rb
+++ b/lib/rubocop/cop/mixin/index_method.rb
@@ -112,7 +112,14 @@ module RuboCop
         end
 
         def self.from_map_to_h(node, match)
-          strip_trailing_chars = node.parent&.block_type? ? 0 : '.to_h'.length
+          strip_trailing_chars = 0
+
+          unless node.parent&.block_type?
+            map_range = node.children.first.source_range
+            node_range = node.source_range
+            strip_trailing_chars = node_range.end_pos - map_range.end_pos
+          end
+
           new(match, node.children.first, 0, strip_trailing_chars)
         end
 

--- a/spec/rubocop/cop/rails/index_by_spec.rb
+++ b/spec/rubocop/cop/rails/index_by_spec.rb
@@ -94,6 +94,34 @@ RSpec.describe RuboCop::Cop::Rails::IndexBy, :config do
     end
   end
 
+  context 'when `to_h` is on a different line' do
+    it 'registers an offense for `map { ... }.to_h`' do
+      expect_offense(<<~RUBY)
+        x.map { |el| [el.to_sym, el] }.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `index_by` over `map { ... }.to_h`.
+          to_h
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x.index_by { |el| el.to_sym }
+      RUBY
+    end
+  end
+
+  context 'when `.to_h` is on a different line' do
+    it 'registers an offense for `map { ... }.to_h`' do
+      expect_offense(<<~RUBY)
+        x.map { |el| [el.to_sym, el] }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `index_by` over `map { ... }.to_h`.
+          .to_h
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x.index_by { |el| el.to_sym }
+      RUBY
+    end
+  end
+
   context 'when to_h is not called on the result' do
     it 'does not register an offense for `map { ... }.to_h`' do
       expect_no_offenses('x.map { |el| [el.to_sym, el] }')


### PR DESCRIPTION
I believe that the test cases included in this commit express well the
problem I'm trying to address, but running the auto-correction against
the following snippet of code:

```rb
x.map { |el| [el.to_sym, el] }.
  to_h
```

Would yield:

```rb
x.index_by { |el| el.to_sym }. # notice the ending "dot"
```

The output isn't parseable/valid Ruby. I belive the problem has to do
with the fact that correction code assumes that the `.to_h` statement is
always grouped together (which isn't true).

The proposed solution was to compute the trailing characters to be
stripped by subtracting the end position of the map block (the `}` character)
from end position of the whole expression.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
