### PR TITLE
Fix an incorrect autocorrect for `Rails/ContentTag` cop

### DIFF
--- a/lib/rubocop/cop/rails/content_tag.rb
+++ b/lib/rubocop/cop/rails/content_tag.rb
@@ -6,6 +6,11 @@ module RuboCop
       # This cop checks that `tag` is used instead of `content_tag`
       # because `content_tag` is legacy syntax.
       #
+      # !!! Note
+      #
+      #    Allow `content_tag` when the first argument is a variable because
+      #    `content_tag(name)` is simpler rather than `tag.public_send(name)`.
+      #
       # @example
       #  # bad
       #  content_tag(:p, 'Hello world!')
@@ -14,6 +19,7 @@ module RuboCop
       #  # good
       #  tag.p('Hello world!')
       #  tag.br
+      #  content_tag(name, 'Hello world!')
       class ContentTag < Cop
         include RangeHelp
         extend TargetRailsVersion
@@ -24,6 +30,9 @@ module RuboCop
 
         def on_send(node)
           return unless node.method?(:content_tag)
+
+          first_argument = node.first_argument
+          return if first_argument.variable? || first_argument.send_type? || first_argument.const_type?
 
           add_offense(node)
         end

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -452,6 +452,11 @@ Enabled | Yes | Yes  | 2.6 | -
 This cop checks that `tag` is used instead of `content_tag`
 because `content_tag` is legacy syntax.
 
+!!! Note
+
+   Allow `content_tag` when the first argument is a variable because
+   `content_tag(name)` is simpler rather than `tag.public_send(name)`.
+
 ### Examples
 
 ```ruby
@@ -462,6 +467,7 @@ content_tag(:br)
 # good
 tag.p('Hello world!')
 tag.br
+content_tag(name, 'Hello world!')
 ```
 
 ### References

--- a/spec/rubocop/cop/rails/content_tag_spec.rb
+++ b/spec/rubocop/cop/rails/content_tag_spec.rb
@@ -114,5 +114,48 @@ RSpec.describe RuboCop::Cop::Rails::ContentTag, :config do
         tag.div() { tag.strong('Hi') }
       RUBY
     end
+
+    context 'when the first argument is a variable' do
+      it 'does not register an offence when the first argument is a lvar' do
+        expect_no_offenses(<<~RUBY)
+          name = do_something
+          content_tag(name, "Hello world!", class: ["strong", "highlight"])
+        RUBY
+      end
+
+      it 'does not register an offence when the first argument is an ivar' do
+        expect_no_offenses(<<~RUBY)
+          content_tag(@name, "Hello world!", class: ["strong", "highlight"])
+        RUBY
+      end
+
+      it 'does not register an offence when the first argument is a cvar' do
+        expect_no_offenses(<<~RUBY)
+          content_tag(@@name, "Hello world!", class: ["strong", "highlight"])
+        RUBY
+      end
+
+      it 'does not register an offence when the first argument is a gvar' do
+        expect_no_offenses(<<~RUBY)
+          content_tag($name, "Hello world!", class: ["strong", "highlight"])
+        RUBY
+      end
+    end
+
+    context 'when the first argument is a method' do
+      it 'does not register an offence' do
+        expect_no_offenses(<<~RUBY)
+          content_tag(name, "Hello world!", class: ["strong", "highlight"])
+        RUBY
+      end
+    end
+
+    context 'when the first argument is a constant' do
+      it 'does not register an offence' do
+        expect_no_offenses(<<~RUBY)
+          content_tag(CONST, "Hello world!", class: ["strong", "highlight"])
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
Follow up to #242.

This PR allows `content_tag` when the first argument is a variable because `content_tag(name)` is simpler rather than `tag.public_send(name)`.

When `public_send` is used, it becomes complicated as follows.

First, `content_tag(name)` cannot be corrected to `tag.name` when the first argument is a variable.

So use `public_send` and prevent the following errors in that case:

## Case 1: Using `public_send` to prevent the following `NoMethodError`

Original code:

```ruby
content_tag(name, 'foo', class: 'bar')
```

Auto-corrected code (before):

```ruby
tag(name, 'foo', class: 'bar')
#=> NoMethodError (undefined method `each_pair' for "foo":String)
```

Auto-corrected code (after):

```ruby
tag.public_send(name, 'foo', class: 'bar')
```

## Case 2: Using `symbolize_keys` to prevent the following `ArgumentError`

Original code:

```ruby
content_tag(name, 'foo', {'class' => 'bar'})
```

Auto-corrected code (before):

```ruby
tag.public_send(name, 'foo', {'class' => 'bar'})
#=> `ArgumentError (wrong number of arguments (given 3, expected 1..2))`
```

Auto-corrected code (after):

```ruby
tag.public_send(name, 'foo', {'class' => 'bar'}.symbolize_keys)
```

The `symbolize_keys` may not be needed, but for safe auto-correction
it will be added if optional argument keys are not all symbols.

## Case 3: Using `o ? o.symbolize_keys : {}` to prevent the following `ArgumentError`

Original code:

```ruby
content_tag(name, 'foo', options)
```

Auto-corrected code (before):

When the third argument is `nil`.

```ruby
options = nil
tag.public_send(name, 'foo', options)
#=> `ArgumentError (wrong number of arguments (given 3, expected 1..2))`
```

Auto-corrected code (after):

```ruby
tag.public_send(name, 'foo', options ? options.symbolize_keys : {})
```

Guard with the empty hash in case the third argument is `nil`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
