### PR TITLE
Ignore ENV.update calls in Rails/SaveBang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * [#12](https://github.com/rubocop-hq/rubocop-rails/issues/12): Fix a false positive for `Rails/SkipsModelValidations` when passing a boolean literal to `touch`. ([@eugeneius][])
 * [#238](https://github.com/rubocop-hq/rubocop-rails/issues/238): Fix auto correction for `Rails/IndexBy` when the `.to_h` invocation is separated in multiple lines. ([@diogoosorio][])
+* [#248](https://github.com/rubocop-hq/rubocop-rails/pull/248): Fix a false positive for `Rails/SaveBang` when `update` is called on `ENV`. ([@eugeneius][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/save_bang.rb
+++ b/lib/rubocop/cop/rails/save_bang.rb
@@ -246,6 +246,7 @@ module RuboCop
 
         def allowed_receiver?(node)
           return false unless node.receiver
+          return true if node.receiver.const_name == 'ENV'
           return false unless cop_config['AllowedReceivers']
 
           cop_config['AllowedReceivers'].any? do |allowed_receiver|

--- a/spec/rubocop/cop/rails/save_bang_spec.rb
+++ b/spec/rubocop/cop/rails/save_bang_spec.rb
@@ -607,4 +607,8 @@ RSpec.describe RuboCop::Cop::Rails::SaveBang, :config do
   it 'properly ignores lvasign without right hand side' do
     expect_no_offenses('variable += 1')
   end
+
+  it 'ignores update when called on ENV' do
+    expect_no_offenses('ENV.update("DISABLE_SPRING" => "1")')
+  end
 end


### PR DESCRIPTION
We can't detect `Hash#update` false positives in the general case, but when the receiver is `ENV` we know it's not an Active Record instance.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/