### PR TITLE
Ignore Rails.root interpolation at end of string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#12](https://github.com/rubocop-hq/rubocop-rails/issues/12): Fix a false positive for `Rails/SkipsModelValidations` when passing a boolean literal to `touch`. ([@eugeneius][])
 * [#238](https://github.com/rubocop-hq/rubocop-rails/issues/238): Fix auto correction for `Rails/IndexBy` when the `.to_h` invocation is separated in multiple lines. ([@diogoosorio][])
 * [#248](https://github.com/rubocop-hq/rubocop-rails/pull/248): Fix a false positive for `Rails/SaveBang` when `update` is called on `ENV`. ([@eugeneius][])
+* [#251](https://github.com/rubocop-hq/rubocop-rails/pull/251): Fix a false positive for `Rails/FilePath` when the result of `Rails.root.join` is interpolated at the end of a string. ([@eugeneius][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/file_path.rb
+++ b/lib/rubocop/cop/rails/file_path.rb
@@ -48,6 +48,7 @@ module RuboCop
 
         def on_dstr(node)
           return unless rails_root_nodes?(node)
+          return unless node.children.last.str_type?
           return unless node.children.last.source.start_with?('.') ||
                         node.children.last.source.include?(File::SEPARATOR)
 

--- a/spec/rubocop/cop/rails/file_path_spec.rb
+++ b/spec/rubocop/cop/rails/file_path_spec.rb
@@ -24,6 +24,14 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       end
     end
 
+    context 'when using Rails.root.join in string interpolation with nothing after it' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~'RUBY')
+          "#{Rails.root.join('log/production.log')}"
+        RUBY
+      end
+    end
+
     context 'when using string interpolation without Rails.root' do
       it 'does not register an offense' do
         expect_no_offenses(<<~'RUBY')
@@ -131,6 +139,14 @@ RSpec.describe RuboCop::Cop::Rails::FilePath, :config do
       it 'does not registers an offense' do
         expect_no_offenses(<<~'RUBY')
           'system "rm -rf #{Rails.root.join(\'a\', \'b.png\')}"'
+        RUBY
+      end
+    end
+
+    context 'when using Rails.root.join in string interpolation with nothing after it' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~'RUBY')
+          "#{Rails.root.join('log', 'production.log')}"
         RUBY
       end
     end


### PR DESCRIPTION
This cop looks for file paths constructed manually by interpolating `Rails.root` into a string. It currently assumes that some literal characters will follow that interpolation, which isn't always the case.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/