### PR TITLE
Update broken link of rails documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Rails/FindBy:
 
 ## Documentation
 
-You can read a lot more about RuboCop Rails in its [official docs](https://docs.rubocop.org/projects/rails/).
+You can read a lot more about RuboCop Rails in its [official docs](https://rails.rubystyle.guide/).
 
 ## Compatibility
 


### PR DESCRIPTION
update broken link to rails documentation in readme file. Now link points to - https://rails.rubystyle.guide/

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
