### PR TITLE
Handle content_tag method calls with no arguments

### DIFF
--- a/lib/rubocop/cop/rails/content_tag.rb
+++ b/lib/rubocop/cop/rails/content_tag.rb
@@ -30,6 +30,8 @@ module RuboCop
           return unless node.method?(:content_tag)
 
           first_argument = node.first_argument
+          return unless first_argument
+
           return if first_argument.variable? || first_argument.send_type? || first_argument.const_type?
 
           add_offense(node)

--- a/spec/rubocop/cop/rails/content_tag_spec.rb
+++ b/spec/rubocop/cop/rails/content_tag_spec.rb
@@ -115,6 +115,12 @@ RSpec.describe RuboCop::Cop::Rails::ContentTag, :config do
       RUBY
     end
 
+    it 'does not register an offense when `content_tag` is called with no arguments' do
+      expect_no_offenses(<<~RUBY)
+        content_tag
+      RUBY
+    end
+
     context 'when the first argument is a variable' do
       it 'does not register an offence when the first argument is a lvar' do
         expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
This cop currently crashes when it encounters a `content_tag` method call with no arguments. The Rails method requires at least one argument, so we can treat a call with no arguments as a false positive.

This is a bug fix for an unreleased cop, so I don't think it needs a changelog entry. Please let me know if I should add one, though.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/