### PR TITLE
Drop support for RuboCop 0.81 or lower

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [#233](https://github.com/rubocop-hq/rubocop-rails/pull/233): **(BREAKING)** Drop support for Ruby 2.3. ([@koic][])
 * [#236](https://github.com/rubocop-hq/rubocop-rails/pull/236): **(BREAKING)** Drop support for Rails 4.1 or lower. ([@koic][])
 * [#210](https://github.com/rubocop-hq/rubocop-rails/issues/210): Accept `redirecto_to(...) and return` and similar cases. ([@koic][])
+* [#258](https://github.com/rubocop-hq/rubocop-rails/pull/258): Drop support for RuboCop 0.81 or lower. ([@koic][])
 
 ## 2.5.2 (2020-04-09)
 

--- a/rubocop-rails.gemspec
+++ b/rubocop-rails.gemspec
@@ -35,5 +35,5 @@ Gem::Specification.new do |s|
   # Rack::Utils::SYMBOL_TO_STATUS_CODE, which is used by HttpStatus cop, was
   # introduced in rack 1.1
   s.add_runtime_dependency 'rack', '>= 1.1'
-  s.add_runtime_dependency 'rubocop', '>= 0.72.0'
+  s.add_runtime_dependency 'rubocop', '>= 0.82.0'
 end


### PR DESCRIPTION
Follow up to https://github.com/rubocop-hq/rubocop-performance/issues/111.

This PR prepares to use RuboCop's new development API.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
