### PR TITLE
Suppress Ruby's warning

### DIFF
--- a/lib/rubocop/cop/rails/uniq_before_pluck.rb
+++ b/lib/rubocop/cop/rails/uniq_before_pluck.rb
@@ -67,8 +67,7 @@ module RuboCop
 
           return unless method
 
-          add_offense(node, location: :selector,
-                            message: format(MSG, method: method))
+          add_offense(node, location: :selector)
         end
 
         def autocorrect(node)


### PR DESCRIPTION
This PR suppresses the following Ruby's warning.

```console
% cd path/to/repo/rubocop-rails
% bundle exec rake
(snip)

/Users/koic/src/github.com/rubocop-hq/rubocop-rails/lib/rubocop/cop/rails/uniq_before_pluck.rb:71:
warning: too many arguments for format string
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
