### PR TITLE
Fix a typo for `Rails/UniqBeforePluck`

### DIFF
--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -3309,7 +3309,7 @@ false positives.
 [source,ruby]
 ----
 # bad
-Model.pluck(:id).distinct
+Model.pluck(:id).uniq
 
 # good
 Model.distinct.pluck(:id)
@@ -3321,14 +3321,14 @@ Model.distinct.pluck(:id)
 ----
 # bad
 # this will return a Relation that pluck is called on
-Model.where(cond: true).pluck(:id).distinct
+Model.where(cond: true).pluck(:id).uniq
 
 # bad
 # an association on an instance will return a CollectionProxy
-instance.assoc.pluck(:id).distinct
+instance.assoc.pluck(:id).uniq
 
 # bad
-Model.pluck(:id).distinct
+Model.pluck(:id).uniq
 
 # good
 Model.distinct.pluck(:id)

--- a/lib/rubocop/cop/rails/uniq_before_pluck.rb
+++ b/lib/rubocop/cop/rails/uniq_before_pluck.rb
@@ -23,7 +23,7 @@ module RuboCop
       #
       # @example EnforcedStyle: conservative (default)
       #   # bad
-      #   Model.pluck(:id).distinct
+      #   Model.pluck(:id).uniq
       #
       #   # good
       #   Model.distinct.pluck(:id)
@@ -31,14 +31,14 @@ module RuboCop
       # @example EnforcedStyle: aggressive
       #   # bad
       #   # this will return a Relation that pluck is called on
-      #   Model.where(cond: true).pluck(:id).distinct
+      #   Model.where(cond: true).pluck(:id).uniq
       #
       #   # bad
       #   # an association on an instance will return a CollectionProxy
-      #   instance.assoc.pluck(:id).distinct
+      #   instance.assoc.pluck(:id).uniq
       #
       #   # bad
-      #   Model.pluck(:id).distinct
+      #   Model.pluck(:id).uniq
       #
       #   # good
       #   Model.distinct.pluck(:id)


### PR DESCRIPTION
Follow up #135.

`Model.pluck(:id).distinct` happens the following `NoMethodError`.

```
NoMethodError: undefined method `distinct' for [42]:Array
```

This PR replaces it with `Array#uniq`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
