### PR TITLE
Change terminology to `ForbiddenMethods` and `AllowedMethods`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ## master (unreleased)
+* [#263](https://github.com/rubocop-hq/rubocop-rails/pull/263): Change terminology to `ForbiddenMethods` and `AllowedMethods`. ([@jcoyne][])
 
 ## 2.6.0 (2020-06-08)
 
@@ -199,3 +200,4 @@
 [@diogoosorio]: https://github.com/diogoosorio
 [@tabuchi0919]: https://github.com/tabuchi0919
 [@ghiculescu]: https://github.com/ghiculescu
+[@jcoyne]: https://github.com/jcoyne

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change log
 
 ## master (unreleased)
+
+### Changes
+
 * [#263](https://github.com/rubocop-hq/rubocop-rails/pull/263): Change terminology to `ForbiddenMethods` and `AllowedMethods`. ([@jcoyne][])
 
 ## 2.6.0 (2020-06-08)

--- a/config/default.yml
+++ b/config/default.yml
@@ -506,7 +506,7 @@ Rails/SkipsModelValidations:
   Enabled: true
   VersionAdded: '0.47'
   VersionChanged: '0.60'
-  Blacklist:
+  ForbiddenMethods:
     - decrement!
     - decrement_counter
     - increment!
@@ -518,7 +518,7 @@ Rails/SkipsModelValidations:
     - update_column
     - update_columns
     - update_counters
-  Whitelist: []
+  AllowedMethods: []
 
 Rails/TimeZone:
   Description: 'Checks the correct usage of time zone aware methods.'

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -3181,11 +3181,11 @@ user.touch
 |===
 | Name | Default value | Configurable values
 
-| Blacklist
+| ForbiddenMethods
 | `decrement!`, `decrement_counter`, `increment!`, `increment_counter`, `toggle!`, `touch`, `update_all`, `update_attribute`, `update_column`, `update_columns`, `update_counters`
 | Array
 
-| Whitelist
+| AllowedMethods
 | `[]`
 | Array
 |===

--- a/legacy-docs/cops_rails.md
+++ b/legacy-docs/cops_rails.md
@@ -2499,8 +2499,8 @@ user.touch
 
 Name | Default value | Configurable values
 --- | --- | ---
-Blacklist | `decrement!`, `decrement_counter`, `increment!`, `increment_counter`, `toggle!`, `touch`, `update_all`, `update_attribute`, `update_column`, `update_columns`, `update_counters` | Array
-Whitelist | `[]` | Array
+ForbiddenMethods | `decrement!`, `decrement_counter`, `increment!`, `increment_counter`, `toggle!`, `touch`, `update_all`, `update_attribute`, `update_column`, `update_columns`, `update_counters` | Array
+AllowedMethods | `[]` | Array
 
 ### References
 

--- a/lib/rubocop/cop/rails/skips_model_validations.rb
+++ b/lib/rubocop/cop/rails/skips_model_validations.rb
@@ -66,6 +66,12 @@ module RuboCop
         end
         alias on_csend on_send
 
+        def initialize(*)
+          super
+          @displayed_allowed_warning = false
+          @displayed_forbidden_warning = false
+        end
+
         private
 
         def message(node)
@@ -78,10 +84,25 @@ module RuboCop
         end
 
         def forbidden_methods
+          obsolete_result = cop_config['Blacklist']
+          if obsolete_result
+            warn '`Blacklist` has been renamed to `ForbiddenMethods`.' unless @displayed_forbidden_warning
+            @displayed_forbidden_warning = true
+            return obsolete_result
+          end
+
           cop_config['ForbiddenMethods'] || []
         end
 
         def allowed_methods
+          obsolete_result = cop_config['Whitelist']
+          if obsolete_result
+            warn '`Whitelist` has been renamed to `AllowedMethods`.' unless @displayed_allowed_warning
+            @displayed_allowed_warning = true
+
+            return obsolete_result
+          end
+
           cop_config['AllowedMethods'] || []
         end
       end

--- a/lib/rubocop/cop/rails/skips_model_validations.rb
+++ b/lib/rubocop/cop/rails/skips_model_validations.rb
@@ -57,8 +57,8 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          return if whitelist.include?(node.method_name.to_s)
-          return unless blacklist.include?(node.method_name.to_s)
+          return if allowed_methods.include?(node.method_name.to_s)
+          return unless forbidden_methods.include?(node.method_name.to_s)
           return if allowed_method?(node)
           return if good_touch?(node)
 
@@ -77,12 +77,12 @@ module RuboCop
             !node.arguments?
         end
 
-        def blacklist
-          cop_config['Blacklist'] || []
+        def forbidden_methods
+          cop_config['ForbiddenMethods'] || []
         end
 
-        def whitelist
-          cop_config['Whitelist'] || []
+        def allowed_methods
+          cop_config['AllowedMethods'] || []
         end
       end
     end

--- a/spec/rubocop/cop/rails/skips_model_validations_spec.rb
+++ b/spec/rubocop/cop/rails/skips_model_validations_spec.rb
@@ -124,4 +124,35 @@ RSpec.describe RuboCop::Cop::Rails::SkipsModelValidations, :config do
       expect_no_offenses('User.touch(:attr)')
     end
   end
+
+  context 'with obsolete Blacklist configuration' do
+    let(:cop_config) do
+      {
+        'Blacklist' => %w[toggle! touch]
+      }
+    end
+
+    it 'warns about renamed forbidden methods' do
+      expect do
+        expect_offense(<<~RUBY)
+          user&.toggle!(:active)
+                ^^^^^^^ Avoid using `toggle!` because it skips validations.
+        RUBY
+      end.to output("`Blacklist` has been renamed to `ForbiddenMethods`.\n").to_stderr
+    end
+  end
+
+  context 'with obsolete Whitelist configuration' do
+    let(:cop_config) do
+      {
+        'Whitelist' => %w[touch]
+      }
+    end
+
+    it 'warns about renamed allowed methods' do
+      expect do
+        expect_no_offenses('User.touch(:attr)')
+      end.to output("`Whitelist` has been renamed to `AllowedMethods`.\n").to_stderr
+    end
+  end
 end

--- a/spec/rubocop/cop/rails/skips_model_validations_spec.rb
+++ b/spec/rubocop/cop/rails/skips_model_validations_spec.rb
@@ -2,17 +2,17 @@
 
 RSpec.describe RuboCop::Cop::Rails::SkipsModelValidations, :config do
   cop_config = {
-    'Blacklist' => %w[decrement!
-                      decrement_counter
-                      increment!
-                      increment_counter
-                      toggle!
-                      touch
-                      update_all
-                      update_attribute
-                      update_column
-                      update_columns
-                      update_counters]
+    'ForbiddenMethods' => %w[decrement!
+                             decrement_counter
+                             increment!
+                             increment_counter
+                             toggle!
+                             touch
+                             update_all
+                             update_attribute
+                             update_column
+                             update_columns
+                             update_counters]
   }
 
   subject(:cop) { described_class.new(config) }
@@ -22,8 +22,8 @@ RSpec.describe RuboCop::Cop::Rails::SkipsModelValidations, :config do
 
   methods_with_arguments = described_class::METHODS_WITH_ARGUMENTS
 
-  context 'with default blacklist' do
-    cop_config['Blacklist'].each do |method_name|
+  context 'with default forbidden methods' do
+    cop_config['ForbiddenMethods'].each do |method_name|
       it "registers an offense for `#{method_name}`" do
         inspect_source("User.#{method_name}(:attr)")
         expect(cop.offenses.size).to eq(1)
@@ -54,7 +54,7 @@ RSpec.describe RuboCop::Cop::Rails::SkipsModelValidations, :config do
   end
 
   context "with methods that don't require an argument" do
-    (cop_config['Blacklist'] - methods_with_arguments).each do |method_name|
+    (cop_config['ForbiddenMethods'] - methods_with_arguments).each do |method_name|
       it "registers an offense for `#{method_name}`" do
         inspect_source("User.#{method_name}")
         expect(cop.offenses.size).to eq(1)
@@ -64,16 +64,16 @@ RSpec.describe RuboCop::Cop::Rails::SkipsModelValidations, :config do
     end
   end
 
-  context 'with `update_attribute` method in blacklist' do
+  context 'with `update_attribute` method in forbidden methods' do
     let(:cop_config) do
-      { 'Blacklist' => %w[update_attribute] }
+      { 'ForbiddenMethods' => %w[update_attribute] }
     end
 
-    whitelist = cop_config['Blacklist'].reject do |val|
+    allowed_methods = cop_config['ForbiddenMethods'].reject do |val|
       val == 'update_attribute'
     end
 
-    whitelist.each do |method_name|
+    allowed_methods.each do |method_name|
       it "accepts `#{method_name}`" do
         expect_no_offenses("User.#{method_name}")
       end
@@ -96,15 +96,15 @@ RSpec.describe RuboCop::Cop::Rails::SkipsModelValidations, :config do
     end
   end
 
-  context 'with whitelist' do
+  context 'with allowed methods' do
     let(:cop_config) do
       {
-        'Blacklist' => %w[toggle! touch],
-        'Whitelist' => %w[touch]
+        'ForbiddenMethods' => %w[toggle! touch],
+        'AllowedMethods' => %w[touch]
       }
     end
 
-    it 'registers an offense for method not in whitelist' do
+    it 'registers an offense for method not in allowed methods' do
       expect_offense(<<~RUBY)
         user.toggle!(:active)
              ^^^^^^^ Avoid using `toggle!` because it skips validations.
@@ -112,7 +112,7 @@ RSpec.describe RuboCop::Cop::Rails::SkipsModelValidations, :config do
     end
 
     context 'when using safe navigation operator' do
-      it 'registers an offense for method not in whitelist' do
+      it 'registers an offense for method not in allowed methods' do
         expect_offense(<<~RUBY)
           user&.toggle!(:active)
                 ^^^^^^^ Avoid using `toggle!` because it skips validations.
@@ -120,7 +120,7 @@ RSpec.describe RuboCop::Cop::Rails::SkipsModelValidations, :config do
       end
     end
 
-    it 'accepts method in whitelist, superseding the blacklist' do
+    it 'accepts method in allowed methods, superseding the forbidden methods' do
       expect_no_offenses('User.touch(:attr)')
     end
   end


### PR DESCRIPTION
Use terminology which is more descriptive and is consistent with the direction of some upstream libraries:
https://github.com/rubocop-hq/rubocop/pull/6467
https://github.com/rails/rails/pull/33681