### PR TITLE
Fix auto correction for `Rails/ContentTag` when `content_tag` is called with options hash and block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#261](https://github.com/rubocop-hq/rubocop-rails/issues/261): Fix auto correction for `Rails/ContentTag` when `content_tag` is called with options hash and block. ([@fatkodima][])
+
 ### Changes
 
 * [#263](https://github.com/rubocop-hq/rubocop-rails/pull/263): Change terminology to `ForbiddenMethods` and `AllowedMethods`. ([@jcoyne][])
@@ -204,3 +208,4 @@
 [@tabuchi0919]: https://github.com/tabuchi0919
 [@ghiculescu]: https://github.com/ghiculescu
 [@jcoyne]: https://github.com/jcoyne
+[@fatkodima]: https://github.com/fatkodima

--- a/spec/rubocop/cop/rails/content_tag_spec.rb
+++ b/spec/rubocop/cop/rails/content_tag_spec.rb
@@ -91,6 +91,20 @@ RSpec.describe RuboCop::Cop::Rails::ContentTag, :config do
       RUBY
     end
 
+    it 'corrects an offense when called with options hash and block' do
+      expect_offense(<<~RUBY)
+        content_tag :div, { class: 'strong' } do
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `tag` instead of `content_tag`.
+          'body'
+        end
+      RUBY
+      expect_correction(<<~RUBY)
+        tag.div({ class: 'strong' }) do
+          'body'
+        end
+      RUBY
+    end
+
     it 'does not register an offence when `tag` is used with an argument' do
       expect_no_offenses(<<~RUBY)
         tag.p('Hello world!')


### PR DESCRIPTION
Closes #261 