### PR TITLE
Update Rails/Pick documentation

### DIFF
--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -2087,7 +2087,11 @@ safe_join([user_content, " ", content_tag(:span, user_content)])
 | -
 |===
 
-This cop enforces the use `pick` over `pluck(...).first`.
+This cop enforces the use of `pick` over `pluck(...).first`.
+
+Using `pluck` followed by `first` creates an intermediate array, which
+`pick` avoids. When called on an Active Record relation, `pick` adds a
+limit to the query so that only one value is fetched from the database.
 
 === Examples
 
@@ -2095,11 +2099,11 @@ This cop enforces the use `pick` over `pluck(...).first`.
 ----
 # bad
 Model.pluck(:a).first
-Model.pluck(:a, :b).first
+[{ a: :b, c: :d }].pluck(:a, :b).first
 
 # good
 Model.pick(:a)
-Model.pick(:a, :b)
+[{ a: :b, c: :d }].pick(:a, :b)
 ----
 
 == Rails/PluckInWhere

--- a/lib/rubocop/cop/rails/pick.rb
+++ b/lib/rubocop/cop/rails/pick.rb
@@ -3,16 +3,20 @@
 module RuboCop
   module Cop
     module Rails
-      # This cop enforces the use `pick` over `pluck(...).first`.
+      # This cop enforces the use of `pick` over `pluck(...).first`.
+      #
+      # Using `pluck` followed by `first` creates an intermediate array, which
+      # `pick` avoids. When called on an Active Record relation, `pick` adds a
+      # limit to the query so that only one value is fetched from the database.
       #
       # @example
       #   # bad
       #   Model.pluck(:a).first
-      #   Model.pluck(:a, :b).first
+      #   [{ a: :b, c: :d }].pluck(:a, :b).first
       #
       #   # good
       #   Model.pick(:a)
-      #   Model.pick(:a, :b)
+      #   [{ a: :b, c: :d }].pick(:a, :b)
       class Pick < Cop
         extend TargetRailsVersion
 


### PR DESCRIPTION
Followup to https://github.com/rubocop-hq/rubocop-rails/pull/249.

 - Fix a grammatical error.
 - Explain why `pick` is preferable.
 - Update an example to show that `pick` works on all enumerables.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/