### PR TITLE
Detect insert_all and friends in Rails/SkipsModelValidations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 ### Changes
 
 * [#263](https://github.com/rubocop-hq/rubocop-rails/pull/263): Change terminology to `ForbiddenMethods` and `AllowedMethods`. ([@jcoyne][])
+* [#289](https://github.com/rubocop-hq/rubocop-rails/pull/289): Update `Rails/SkipsModelValidations` to register an offense for `insert_all`, `touch_all`, `upsert_all`, etc. ([@eugeneius][])
 
 ## 2.6.0 (2020-06-08)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -588,19 +588,26 @@ Rails/SkipsModelValidations:
   Reference: 'https://guides.rubyonrails.org/active_record_validations.html#skipping-validations'
   Enabled: true
   VersionAdded: '0.47'
-  VersionChanged: '0.60'
+  VersionChanged: '2.7'
   ForbiddenMethods:
     - decrement!
     - decrement_counter
     - increment!
     - increment_counter
+    - insert
+    - insert!
+    - insert_all
+    - insert_all!
     - toggle!
     - touch
+    - touch_all
     - update_all
     - update_attribute
     - update_column
     - update_columns
     - update_counters
+    - upsert
+    - upsert_all
   AllowedMethods: []
 
 Rails/TimeZone:

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -3618,7 +3618,7 @@ l Time.now
 | Yes
 | No
 | 0.47
-| 0.60
+| 2.7
 |===
 
 This cop checks for the use of methods which skip
@@ -3667,7 +3667,7 @@ user.touch
 | Name | Default value | Configurable values
 
 | ForbiddenMethods
-| `decrement!`, `decrement_counter`, `increment!`, `increment_counter`, `toggle!`, `touch`, `update_all`, `update_attribute`, `update_column`, `update_columns`, `update_counters`
+| `decrement!`, `decrement_counter`, `increment!`, `increment_counter`, `insert`, `insert!`, `insert_all`, `insert_all!`, `toggle!`, `touch`, `touch_all`, `update_all`, `update_attribute`, `update_column`, `update_columns`, `update_counters`, `upsert`, `upsert_all`
 | Array
 
 | AllowedMethods

--- a/lib/rubocop/cop/rails/skips_model_validations.rb
+++ b/lib/rubocop/cop/rails/skips_model_validations.rb
@@ -42,12 +42,18 @@ module RuboCop
                                     decrement_counter
                                     increment!
                                     increment_counter
+                                    insert
+                                    insert!
+                                    insert_all
+                                    insert_all!
                                     toggle!
                                     update_all
                                     update_attribute
                                     update_column
                                     update_columns
-                                    update_counters].freeze
+                                    update_counters
+                                    upsert
+                                    upsert_all].freeze
 
         def_node_matcher :good_touch?, <<~PATTERN
           {

--- a/spec/rubocop/cop/rails/skips_model_validations_spec.rb
+++ b/spec/rubocop/cop/rails/skips_model_validations_spec.rb
@@ -6,13 +6,20 @@ RSpec.describe RuboCop::Cop::Rails::SkipsModelValidations, :config do
                              decrement_counter
                              increment!
                              increment_counter
+                             insert
+                             insert!
+                             insert_all
+                             insert_all!
                              toggle!
                              touch
+                             touch_all
                              update_all
                              update_attribute
                              update_column
                              update_columns
-                             update_counters]
+                             update_counters
+                             upsert
+                             upsert_all]
   }
 
   subject(:cop) { described_class.new(config) }


### PR DESCRIPTION
Follows https://github.com/rails/rails/commit/0cb67a6307e0850dae285120e0292b7056c05237 and https://github.com/rails/rails/commit/e6f8bfe1dc2675eedc5fa42eb8ee92504ec11240.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/