### PR TITLE
Fix insert false positives in SkipsModelValidations

### DIFF
--- a/lib/rubocop/cop/rails/skips_model_validations.rb
+++ b/lib/rubocop/cop/rails/skips_model_validations.rb
@@ -62,11 +62,19 @@ module RuboCop
           }
         PATTERN
 
+        def_node_matcher :good_insert?, <<~PATTERN
+          (send _ {:insert :insert!} _ {
+            !(hash ...)
+            (hash <(pair (sym !{:returning :unique_by}) _) ...>)
+          } ...)
+        PATTERN
+
         def on_send(node)
           return if allowed_methods.include?(node.method_name.to_s)
           return unless forbidden_methods.include?(node.method_name.to_s)
           return if allowed_method?(node)
           return if good_touch?(node)
+          return if good_insert?(node)
 
           add_offense(node, location: :selector)
         end


### PR DESCRIPTION
Adding `insert` to the forbidden methods list for SkipsModelValidations in https://github.com/rubocop-hq/rubocop-rails/pull/289 introduced false positives, particularly since [`String#insert`](https://ruby-doc.org/core-2.7.1/String.html#method-i-insert) and [`Array#insert`](https://ruby-doc.org/core-2.7.1/Array.html#method-i-insert) are commonly used.

We can reduce the impact by matching on the arguments: [Active Record's `insert` method](https://api.rubyonrails.org/classes/ActiveRecord/Persistence/ClassMethods.html#method-i-insert) takes one positional argument and two optional keyword arguments (`:returning` and `:unique_by`). Anything else can be ignored.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/