### PR TITLE
Handle undefined DidYouMean constants in UnknownEnv cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#297](https://github.com/rubocop-hq/rubocop-rails/pull/297): Handle an upstream Ruby issue where the DidYouMean module is not available, which would break the `Rails/UnknownEnv` cop. ([@taylorthurlow][])
+
 ## 2.7.0 (2020-07-21)
 
 ### New features
@@ -230,3 +234,4 @@
 [@ghiculescu]: https://github.com/ghiculescu
 [@jcoyne]: https://github.com/jcoyne
 [@fatkodima]: https://github.com/fatkodima
+[@taylorthurlow]: https://github.com/taylorthurlow

--- a/lib/rubocop/cop/rails/unknown_env.rb
+++ b/lib/rubocop/cop/rails/unknown_env.rb
@@ -56,8 +56,16 @@ module RuboCop
         def message(name)
           name = name.to_s.chomp('?')
 
-          spell_checker = DidYouMean::SpellChecker.new(dictionary: environments)
-          similar_names = spell_checker.correct(name)
+          # DidYouMean::SpellChecker is not available in all versions of Ruby,
+          # and even on versions where it *is* available (>= 2.3), it is not
+          # always required correctly. So we do a feature check first. See:
+          # https://github.com/rubocop-hq/rubocop/issues/7979
+          similar_names = if defined?(DidYouMean::SpellChecker)
+                            spell_checker = DidYouMean::SpellChecker.new(dictionary: environments)
+                            spell_checker.correct(name)
+                          else
+                            []
+                          end
 
           if similar_names.empty?
             format(MSG, name: name)


### PR DESCRIPTION
The rubocop gem itself has a closed issue here:

https://github.com/rubocop-hq/rubocop/issues/7979

It details the fact that the DidYouMean constants are sometimes not
loaded even though the DidYouMean gem has been a part of Ruby since 2.3,
and should be required by default. The rubocop gem maintainers
determined this to be an upstream issue.

Here are some other relevant links to issues/PRs:

https://github.com/ruby/did_you_mean/issues/117
https://github.com/rubocop-hq/rubocop/pull/8143

My solution is mostly a band-aid fix to handle this problem until it is
fixed - use the DidYouMean spell checker if it is defined, otherwise
skip spell checking if it is not.

The changes to the specs might be considered "questionable", as I also added a
`defined?` check to the spec. This should also fix the issue noted in the
associated spec file about DidYouMean being undefined in CI. While this message
is more or less correct, the issue is obviously, based on this PR, not specific
to JRuby or CI.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/