### PR TITLE
Fix documentation rake task to support v1-style autocorrect

### DIFF
--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -46,7 +46,7 @@ task generate_cops_documentation: :yard_for_generate_documentation do
       'Enabled by default', 'Safe', 'Supports autocorrection', 'VersionAdded',
       'VersionChanged'
     ]
-    autocorrect = if cop_instance.support_autocorrect?
+    autocorrect = if cop_instance.class.support_autocorrect?
                     "Yes#{' (Unsafe)' unless cop_instance.safe_autocorrect?}"
                   else
                     'No'


### PR DESCRIPTION
Seen in https://github.com/rubocop-hq/rubocop-rails/pull/299

This PR modifies `generate_cops_documentation` rake to support [v1-style autocorrect by extending AutoCorrector](https://docs.rubocop.org/rubocop/v1_upgrade_notes.html).

Fix taken from rubocop: https://github.com/rubocop-hq/rubocop/blob/343f62e4555be0470326f47af219689e21c61a37/tasks/cops_documentation.rake#L50

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/