### PR TITLE
[Fix #300] Fix `Rails/RenderInline` error on variable key in render options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#297](https://github.com/rubocop-hq/rubocop-rails/pull/297): Handle an upstream Ruby issue where the DidYouMean module is not available, which would break the `Rails/UnknownEnv` cop. ([@taylorthurlow][])
+* [#300](https://github.com/rubocop-hq/rubocop-rails/issues/300): Fix `Rails/RenderInline` error on variable key in render options. ([@tejasbubane][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/render_inline.rb
+++ b/lib/rubocop/cop/rails/render_inline.rb
@@ -27,20 +27,12 @@ module RuboCop
       class RenderInline < Cop
         MSG = 'Prefer using a template over inline rendering.'
 
-        def_node_matcher :render_with_options?, <<~PATTERN
-          (send nil? :render $(hash ...))
+        def_node_matcher :render_with_inline_option?, <<~PATTERN
+          (send nil? :render (hash <(pair {(sym :inline) (str "inline")} _) ...>))
         PATTERN
 
         def on_send(node)
-          render_with_options?(node) do |options|
-            add_offense(node) if includes_inline_key?(options)
-          end
-        end
-
-        private
-
-        def includes_inline_key?(node)
-          node.keys.find { |key| key.value.to_sym == :inline }
+          add_offense(node) if render_with_inline_option?(node)
         end
       end
     end

--- a/spec/rubocop/cop/rails/render_inline_spec.rb
+++ b/spec/rubocop/cop/rails/render_inline_spec.rb
@@ -22,4 +22,17 @@ RSpec.describe RuboCop::Cop::Rails::RenderInline do
       render :index
     RUBY
   end
+
+  it 'does not register an offense when passing other options to render' do
+    expect_no_offenses(<<~RUBY)
+      render json: users, serializer: UserSerializer
+    RUBY
+  end
+
+  it 'does not register an offense when passing other options where key is a variable' do
+    expect_no_offenses(<<~RUBY)
+      serializer = users.respond_to?(:each) ? :each_serializer : :serializer
+      render json: users, serializer => UserSerializer
+    RUBY
+  end
 end


### PR DESCRIPTION
Closes: https://github.com/rubocop-hq/rubocop-rails/issues/300

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/