### PR TITLE
[Fix #305] Fix crash in `Rails/MatchRoute` cop when `via` option is a variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#297](https://github.com/rubocop-hq/rubocop-rails/pull/297): Handle an upstream Ruby issue where the DidYouMean module is not available, which would break the `Rails/UnknownEnv` cop. ([@taylorthurlow][])
 * [#300](https://github.com/rubocop-hq/rubocop-rails/issues/300): Fix `Rails/RenderInline` error on variable key in render options. ([@tejasbubane][])
+* [#305](https://github.com/rubocop-hq/rubocop-rails/issues/305): Fix crash in `Rails/MatchRoute` cop when `via` option is a variable. ([@tejasbubane][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/match_route.rb
+++ b/lib/rubocop/cop/rails/match_route.rb
@@ -77,6 +77,8 @@ module RuboCop
             [via.value]
           elsif via.array_type?
             via.values.map(&:value)
+          else
+            []
           end
         end
 

--- a/spec/rubocop/cop/rails/match_route_spec.rb
+++ b/spec/rubocop/cop/rails/match_route_spec.rb
@@ -63,6 +63,21 @@ RSpec.describe RuboCop::Cop::Rails::MatchRoute do
     RUBY
   end
 
+  it 'registers an offense when using match with string interpolation' do
+    expect_offense(<<~'RUBY')
+      routes.draw do
+        match "#{resource}/:action/:id", via: [:put]
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `put` instead of `match` to define a route.
+      end
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      routes.draw do
+        put "#{resource}/:action/:id"
+      end
+    RUBY
+  end
+
   it 'does not register an offense when not within routes' do
     expect_no_offenses(<<~RUBY)
       match 'photos/:id', to: 'photos#show', via: :get
@@ -89,6 +104,14 @@ RSpec.describe RuboCop::Cop::Rails::MatchRoute do
     expect_no_offenses(<<~RUBY)
       routes.draw do
         get 'photos/:id', to: 'photos#show'
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when via is a variable' do
+    expect_no_offenses(<<~'RUBY')
+      routes.draw do
+        match ':controller/:action/:id', via: method
       end
     RUBY
   end


### PR DESCRIPTION
Closes #305

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/