### PR TITLE
[Bugfix] Allow to use frozen scope for Rails/UniqueValidationWithoutIndex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Bug fixes
 
+* [#315](https://github.com/rubocop-hq/rubocop-rails/pull/315): Allow to use frozen scope for `Rails/UniqueValidationWithoutIndex`. ([@krim][])
 * [#313](https://github.com/rubocop-hq/rubocop-rails/pull/313): Fix `Rails/ActiveRecordCallbacksOrder` to preserve the original callback execution order. ([@eugeneius][])
 
 ### Changes
@@ -256,3 +257,4 @@
 [@jcoyne]: https://github.com/jcoyne
 [@fatkodima]: https://github.com/fatkodima
 [@taylorthurlow]: https://github.com/taylorthurlow
+[@krim]: https://github.com/krim

--- a/lib/rubocop/cop/rails/unique_validation_without_index.rb
+++ b/lib/rubocop/cop/rails/unique_validation_without_index.rb
@@ -97,6 +97,8 @@ module RuboCop
           scope = find_scope(uniq)
           return unless scope
 
+          scope = unfreeze_scope(scope)
+
           case scope.type
           when :sym, :str
             [scope.value]
@@ -112,6 +114,10 @@ module RuboCop
 
             break pair.value
           end
+        end
+
+        def unfreeze_scope(scope)
+          scope.send_type? && scope.method?(:freeze) ? scope.children.first : scope
         end
 
         def class_node(node)

--- a/spec/rubocop/cop/rails/unique_validation_without_index_spec.rb
+++ b/spec/rubocop/cop/rails/unique_validation_without_index_spec.rb
@@ -179,6 +179,16 @@ RSpec.describe RuboCop::Cop::Rails::UniqueValidationWithoutIndex, :config do
             end
           RUBY
         end
+
+        context 'when scope is frozen' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<~RUBY)
+              class WrittenArticles
+                validates :a_id, uniqueness: { scope: [:b_id, :c_id].freeze }
+              end
+            RUBY
+          end
+        end
       end
     end
 


### PR DESCRIPTION
AST tree for a frozen object looks like:
```ruby
=> s(:send,
  s(:array,
    s(:sym, :b_id),
    s(:sym, :c_id)), :freeze)
```
The type for that is `send`, so it fails to detect the correct type for a scope.