### PR TITLE
[Fix #311] Make `Rails/HelperInstanceVariable` aware of memoization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#52](https://github.com/rubocop-hq/rubocop-rails/issues/52): Add new `Rails/AfterCommitOverride` cop. ([@fatkodima][])
 * [#274](https://github.com/rubocop-hq/rubocop-rails/pull/274): Add new `Rails/WhereNot` cop. ([@fatkodima][])
+* [#311](https://github.com/rubocop-hq/rubocop-rails/issues/311): Make `Rails/HelperInstanceVariable` aware of memoization. ([@koic][])
 
 ### Bug fixes
 

--- a/lib/rubocop/cop/rails/helper_instance_variable.rb
+++ b/lib/rubocop/cop/rails/helper_instance_variable.rb
@@ -31,6 +31,8 @@ module RuboCop
         end
 
         def on_ivasgn(node)
+          return if node.parent.or_asgn_type?
+
           add_offense(node, location: :name)
         end
       end

--- a/spec/rubocop/cop/rails/helper_instance_variable_spec.rb
+++ b/spec/rubocop/cop/rails/helper_instance_variable_spec.rb
@@ -28,4 +28,12 @@ RSpec.describe RuboCop::Cop::Rails::HelperInstanceVariable do
       end
     RUBY
   end
+
+  it 'does not register an offense when using memoization' do
+    expect_no_offenses(<<~'RUBY')
+      def foo
+        @cache ||= heavy_load
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #311

This PR makes `Rails/HelperInstanceVariable` aware of memoization.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
