### PR TITLE
[Fix #319] Fix a false positive for `Rails/Inquiry`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * [#315](https://github.com/rubocop-hq/rubocop-rails/pull/315): Allow to use frozen scope for `Rails/UniqueValidationWithoutIndex`. ([@krim][])
 * [#313](https://github.com/rubocop-hq/rubocop-rails/pull/313): Fix `Rails/ActiveRecordCallbacksOrder` to preserve the original callback execution order. ([@eugeneius][])
+* [#319](https://github.com/rubocop-hq/rubocop-rails/issues/319): Fix a false positive for `Rails/Inquiry` when `#inquiry`'s receiver is a variable. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/inquiry.rb
+++ b/lib/rubocop/cop/rails/inquiry.rb
@@ -26,7 +26,11 @@ module RuboCop
         MSG = "Prefer Ruby's comparison operators over Active Support's `inquiry`."
 
         def on_send(node)
-          add_offense(node, location: :selector) if node.method?(:inquiry) && node.arguments.empty?
+          return unless node.method?(:inquiry) && node.arguments.empty?
+          return unless (receiver = node.receiver)
+          return if !receiver.str_type? && !receiver.array_type?
+
+          add_offense(node, location: :selector)
         end
       end
     end

--- a/spec/rubocop/cop/rails/inquiry_spec.rb
+++ b/spec/rubocop/cop/rails/inquiry_spec.rb
@@ -3,16 +3,35 @@
 RSpec.describe RuboCop::Cop::Rails::Inquiry do
   subject(:cop) { described_class.new }
 
-  it 'registers an offense when using `#inquiry`' do
+  it 'registers an offense when using `String#inquiry`' do
     expect_offense(<<~RUBY)
       'two'.inquiry
             ^^^^^^^ Prefer Ruby's comparison operators over Active Support's `inquiry`.
     RUBY
   end
 
+  it 'registers an offense when using `Array#inquiry`' do
+    expect_offense(<<~RUBY)
+      [foo, bar].inquiry
+                 ^^^^^^^ Prefer Ruby's comparison operators over Active Support's `inquiry`.
+    RUBY
+  end
+
+  it 'does not register an offense when `#inquiry` with no receiver' do
+    expect_no_offenses(<<~RUBY)
+      inquiry
+    RUBY
+  end
+
+  it "does not register an offense when `#inquiry`'s receiver is a variable" do
+    expect_no_offenses(<<~RUBY)
+      foo.inquiry
+    RUBY
+  end
+
   it 'does not register an offense when using `#inquiry` with arguments' do
     expect_no_offenses(<<~RUBY)
-      foo.inquiry(bar)
+      'foo'.inquiry(bar)
     RUBY
   end
 end


### PR DESCRIPTION
Fixes #319.

This PR fixes a false positive for `Rails/Inquiry` when `#inquiry`'s receiver is a variable.
It should only detect when receiver is an array literal and a string literal.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
