### PR TITLE
Handle to_h with block in Rails/IndexBy and Rails/IndexWith

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#294](https://github.com/rubocop-hq/rubocop-rails/pull/294): Update `Rails/ReversibleMigration` to register offenses for `remove_columns` and `remove_index`. ([@philcoggins][])
 * [#310](https://github.com/rubocop-hq/rubocop-rails/issues/310): Add `EnforcedStyle` to `Rails/PluckInWhere`. By default, it does not register an offense if `pluck` method's receiver is a variable. ([@koic][])
 * [#320](https://github.com/rubocop-hq/rubocop-rails/pull/320): Mark `Rails/UniqBeforePluck` as unsafe. ([@kunitoo][])
+* [#324](https://github.com/rubocop-hq/rubocop-rails/pull/324): Make `Rails/IndexBy` and `Rails/IndexWith` aware of `to_h` with block. ([@eugeneius][])
 
 ## 2.7.1 (2020-07-26)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -321,14 +321,16 @@ Rails/IgnoredSkipActionFilterOption:
     - app/controllers/**/*.rb
 
 Rails/IndexBy:
-  Description: 'Prefer `index_by` over `each_with_object` or `map`.'
+  Description: 'Prefer `index_by` over `each_with_object`, `to_h`, or `map`.'
   Enabled: true
   VersionAdded: '2.5'
+  VersionChanged: '2.8'
 
 Rails/IndexWith:
-  Description: 'Prefer `index_with` over `each_with_object` or `map`.'
+  Description: 'Prefer `index_with` over `each_with_object`, `to_h`, or `map`.'
   Enabled: true
   VersionAdded: '2.5'
+  VersionChanged: '2.8'
 
 Rails/Inquiry:
   Description: "Prefer Ruby's comparison operators over Active Support's `Array#inquiry` and `String#inquiry`."

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -1696,7 +1696,7 @@ end
 | Yes
 | Yes
 | 2.5
-| -
+| 2.8
 |===
 
 This cop looks for uses of `each_with_object({}) { ... }`,
@@ -1710,6 +1710,7 @@ Rails provides the `index_by` method for this purpose.
 ----
 # bad
 [1, 2, 3].each_with_object({}) { |el, h| h[foo(el)] = el }
+[1, 2, 3].to_h { |el| [foo(el), el] }
 [1, 2, 3].map { |el| [foo(el), el] }.to_h
 Hash[[1, 2, 3].collect { |el| [foo(el), el] }]
 
@@ -1726,7 +1727,7 @@ Hash[[1, 2, 3].collect { |el| [foo(el), el] }]
 | Yes
 | Yes
 | 2.5
-| -
+| 2.8
 |===
 
 This cop looks for uses of `each_with_object({}) { ... }`,
@@ -1740,6 +1741,7 @@ Rails provides the `index_with` method for this purpose.
 ----
 # bad
 [1, 2, 3].each_with_object({}) { |el, h| h[el] = foo(el) }
+[1, 2, 3].to_h { |el| [el, foo(el)] }
 [1, 2, 3].map { |el| [el, foo(el)] }.to_h
 Hash[[1, 2, 3].collect { |el| [el, foo(el)] }]
 

--- a/lib/rubocop/cop/rails/index_by.rb
+++ b/lib/rubocop/cop/rails/index_by.rb
@@ -11,6 +11,7 @@ module RuboCop
       # @example
       #   # bad
       #   [1, 2, 3].each_with_object({}) { |el, h| h[foo(el)] = el }
+      #   [1, 2, 3].to_h { |el| [foo(el), el] }
       #   [1, 2, 3].map { |el| [foo(el), el] }.to_h
       #   Hash[[1, 2, 3].collect { |el| [foo(el), el] }]
       #
@@ -24,6 +25,13 @@ module RuboCop
             ({send csend} _ :each_with_object (hash))
             (args (arg $_el) (arg _memo))
             ({send csend} (lvar _memo) :[]= $_ (lvar _el)))
+        PATTERN
+
+        def_node_matcher :on_bad_to_h, <<~PATTERN
+          (block
+            ({send csend} _ :to_h)
+            (args (arg $_el))
+            (array $_ (lvar _el)))
         PATTERN
 
         def_node_matcher :on_bad_map_to_h, <<~PATTERN

--- a/lib/rubocop/cop/rails/index_with.rb
+++ b/lib/rubocop/cop/rails/index_with.rb
@@ -11,6 +11,7 @@ module RuboCop
       # @example
       #   # bad
       #   [1, 2, 3].each_with_object({}) { |el, h| h[el] = foo(el) }
+      #   [1, 2, 3].to_h { |el| [el, foo(el)] }
       #   [1, 2, 3].map { |el| [el, foo(el)] }.to_h
       #   Hash[[1, 2, 3].collect { |el| [el, foo(el)] }]
       #
@@ -27,6 +28,13 @@ module RuboCop
             ({send csend} _ :each_with_object (hash))
             (args (arg $_el) (arg _memo))
             ({send csend} (lvar _memo) :[]= (lvar _el) $_))
+        PATTERN
+
+        def_node_matcher :on_bad_to_h, <<~PATTERN
+          (block
+            ({send csend} _ :to_h)
+            (args (arg $_el))
+            (array (lvar _el) $_))
         PATTERN
 
         def_node_matcher :on_bad_map_to_h, <<~PATTERN

--- a/spec/rubocop/cop/rails/index_by_spec.rb
+++ b/spec/rubocop/cop/rails/index_by_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe RuboCop::Cop::Rails::IndexBy, :config do
   end
 
   context 'when `to_h` is given a block' do
-    it 'registers an offense for `map { ... }.to_h' do
+    it 'registers an offense for `map { ... }.to_h`' do
       expect_offense(<<~RUBY)
         x.map { |el| [el.to_sym, el] }.to_h { |k, v| [v, k] }
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `index_by` over `map { ... }.to_h`.
@@ -137,5 +137,26 @@ RSpec.describe RuboCop::Cop::Rails::IndexBy, :config do
     expect_correction(<<~RUBY)
       x.index_by { |el| el.to_sym }
     RUBY
+  end
+
+  context 'when using Ruby 2.6 or newer', :ruby26 do
+    it 'registers an offense for `to_h { ... }`' do
+      expect_offense(<<~RUBY)
+        x.to_h { |el| [el.to_sym, el] }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `index_by` over `to_h { ... }`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        x.index_by { |el| el.to_sym }
+      RUBY
+    end
+  end
+
+  context 'when using Ruby 2.5 or older', :ruby25 do
+    it 'does not register an offense for `to_h { ... }`' do
+      expect_no_offenses(<<~RUBY)
+        x.to_h { |el| [el.to_sym, el] }
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Followup to https://github.com/rubocop-hq/rubocop-rails/pull/208.
See also https://github.com/rubocop-hq/rubocop/pull/8517.

Since Ruby 2.6, `Enumerable#to_h` accepts a block which is called with each element and must return a key and value to include in the new hash: https://rubyreferences.github.io/rubychanges/2.6.html#to_h-with-a-block

If the element is always returned as either the key or the value, using `Enumerable#index_by` or `Enumerable#index_with` is faster and clearer.

This is similar to the existing logic that detects `map { ... }.to_h`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/