### PR TITLE
Fixes auto-correct of content_tag with hyphenated tag name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#315](https://github.com/rubocop-hq/rubocop-rails/pull/315): Allow to use frozen scope for `Rails/UniqueValidationWithoutIndex`. ([@krim][])
 * [#313](https://github.com/rubocop-hq/rubocop-rails/pull/313): Fix `Rails/ActiveRecordCallbacksOrder` to preserve the original callback execution order. ([@eugeneius][])
 * [#319](https://github.com/rubocop-hq/rubocop-rails/issues/319): Fix a false positive for `Rails/Inquiry` when `#inquiry`'s receiver is a variable. ([@koic][])
+* [#327](https://github.com/rubocop-hq/rubocop-rails/pull/327): Fix `Rails/ContentTag` autocorrect to handle html5 tag names with hyphens. ([@jaredmoody][])
 
 ### Changes
 
@@ -266,3 +267,4 @@
 [@krim]: https://github.com/krim
 [@philcoggins]: https://github.com/philcoggins
 [@kunitoo]: https://github.com/kunitoo
+[@jaredmoody]: https://github.com/jaredmoody

--- a/lib/rubocop/cop/rails/content_tag.rb
+++ b/lib/rubocop/cop/rails/content_tag.rb
@@ -43,7 +43,7 @@ module RuboCop
               range = correction_range(node)
 
               rest_args = node.arguments.drop(1)
-              replacement = "tag.#{node.first_argument.value}(#{rest_args.map(&:source).join(', ')})"
+              replacement = "tag.#{node.first_argument.value.to_s.underscore}(#{rest_args.map(&:source).join(', ')})"
 
               corrector.replace(range, replacement)
             else
@@ -57,7 +57,7 @@ module RuboCop
         def method_name?(node)
           return false unless node.str_type? || node.sym_type?
 
-          /^[a-zA-Z_][a-zA-Z_0-9]*$/.match?(node.value)
+          /^[a-zA-Z_][a-zA-Z_\-0-9]*$/.match?(node.value)
         end
 
         def correction_range(node)

--- a/spec/rubocop/cop/rails/content_tag_spec.rb
+++ b/spec/rubocop/cop/rails/content_tag_spec.rb
@@ -83,11 +83,11 @@ RSpec.describe RuboCop::Cop::Rails::ContentTag, :config do
 
     it 'corrects an offence when first argument is non-identifier string' do
       expect_offense(<<~RUBY)
-        content_tag('foo-bar')
-        ^^^^^^^^^^^^^^^^^^^^^^ Use `tag` instead of `content_tag`.
+        content_tag('foo-bar', 'baz', class: 'strong')
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `tag` instead of `content_tag`.
       RUBY
       expect_correction(<<~RUBY)
-        tag('foo-bar')
+        tag.foo_bar('baz', class: 'strong')
       RUBY
     end
 


### PR DESCRIPTION
Allow auto-correction of tag names with hyphen, e.g. `trix-editor` to
`tag.trix_editor` instead of correcting to deprecated
`tag('trix-editor')` syntax.

The deprecated syntax does not support a content parameter, so the
arguments in the corrected code were incorrect when correcting a
method name with a hyphen and content, such as
`content_tag('trix-editor' 'my content!')`