### PR TITLE
Mark `Rails/UniqBeforePluck` cop as unsafe auto-correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 * [#312](https://github.com/rubocop-hq/rubocop-rails/pull/312): Mark `Rails/MailerName` as unsafe for auto-correct. ([@eugeneius][])
 * [#294](https://github.com/rubocop-hq/rubocop-rails/pull/294): Update `Rails/ReversibleMigration` to register offenses for `remove_columns` and `remove_index`. ([@philcoggins][])
 * [#310](https://github.com/rubocop-hq/rubocop-rails/issues/310): Add `EnforcedStyle` to `Rails/PluckInWhere`. By default, it does not register an offense if `pluck` method's receiver is a variable. ([@koic][])
-* [#320](https://github.com/rubocop-hq/rubocop-rails/pull/320): Mark `Rails/UniqBeforePluck` as unsafe. ([@kunitoo][])
+* [#320](https://github.com/rubocop-hq/rubocop-rails/pull/320): Mark `Rails/UniqBeforePluck` as unsafe auto-correction. ([@kunitoo][])
 * [#324](https://github.com/rubocop-hq/rubocop-rails/pull/324): Make `Rails/IndexBy` and `Rails/IndexWith` aware of `to_h` with block. ([@eugeneius][])
 
 ## 2.7.1 (2020-07-26)

--- a/config/default.yml
+++ b/config/default.yml
@@ -664,7 +664,7 @@ Rails/UniqBeforePluck:
   SupportedStyles:
     - conservative
     - aggressive
-  Safe: false
+  SafeAutoCorrect: false
   AutoCorrect: false
 
 Rails/UniqueValidationWithoutIndex:

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -3979,7 +3979,7 @@ Time.at(timestamp).in_time_zone
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
 | Enabled
-| No
+| Yes
 | Yes (Unsafe)
 | 0.40
 | 2.8


### PR DESCRIPTION
Follow #320 and https://github.com/rubocop-hq/rubocop/pull/8529.

This PR changes the mark of `Rails/UniqBeforePluck` from `Safe: false` to `SafeAutoCorrect: false`.

False positives to detection are not a concern. Only worry about incompatibilities with auto-correction.

Below is an excerpt from the official document.

> * Safe (true/false) - indicates whether the cop can yield false positives (by design) or not.
>
> * SafeAutoCorrect (true/false) - indicates whether the auto-correct a cop does is safe (equivalent) by design. If a cop is unsafe its auto-correct automatically becomes unsafe as well.

https://docs.rubocop.org/rubocop/0.89/usage/auto_correct.html#safe-auto-correct

Cc @kunitoo 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
