### PR TITLE
[Fix #332] Fix false negative for `Rails/ReflectionClassName`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#323](https://github.com/rubocop-hq/rubocop-rails/pull/323): Add new `Rails/OrderById` cop. ([@fatkodima][])
 * [#274](https://github.com/rubocop-hq/rubocop-rails/pull/274): Add new `Rails/WhereNot` cop. ([@fatkodima][])
 * [#311](https://github.com/rubocop-hq/rubocop-rails/issues/311): Make `Rails/HelperInstanceVariable` aware of memoization. ([@koic][])
+* [#332](https://github.com/rubocop-hq/rubocop-rails/issues/332): Fix `Rails/ReflectionClassName` cop false negative when relation had a scope parameter. ([@bubaflub][])
 
 ### Bug fixes
 
@@ -35,7 +36,7 @@
 
 ### Changes
 
-* [#301](https://github.com/rubocop-hq/rubocop-rails/issues/301): Set disalbed by default for `Rails/PluckId`. ([@koic][])
+* [#301](https://github.com/rubocop-hq/rubocop-rails/issues/301): Set disabled by default for `Rails/PluckId`. ([@koic][])
 
 ## 2.7.0 (2020-07-21)
 
@@ -271,3 +272,4 @@
 [@kunitoo]: https://github.com/kunitoo
 [@jaredmoody]: https://github.com/jaredmoody
 [@mobilutz]: https://github.com/mobilutz
+[@bubaflub]: https://github.com/bubaflub

--- a/lib/rubocop/cop/rails/reflection_class_name.rb
+++ b/lib/rubocop/cop/rails/reflection_class_name.rb
@@ -17,7 +17,7 @@ module RuboCop
         MSG = 'Use a string value for `class_name`.'
 
         def_node_matcher :association_with_reflection, <<~PATTERN
-          (send nil? {:has_many :has_one :belongs_to} _
+          (send nil? {:has_many :has_one :belongs_to} _ _ ?
             (hash <$#reflection_class_name ...>)
           )
         PATTERN

--- a/spec/rubocop/cop/rails/reflection_class_name_spec.rb
+++ b/spec/rubocop/cop/rails/reflection_class_name_spec.rb
@@ -35,6 +35,15 @@ RSpec.describe RuboCop::Cop::Rails::ReflectionClassName do
     end
   end
 
+  context 'when a relation has a scope parameter' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        belongs_to :account, -> { distinct }, class_name: Account
+                                              ^^^^^^^^^^^^^^^^^^^ Use a string value for `class_name`.
+      RUBY
+    end
+  end
+
   it 'does not register an offense when using string with interpolation' do
     expect_no_offenses(<<~'RUBY')
       has_many :accounts, class_name: "#{prefix}Account"


### PR DESCRIPTION
This PR fixes a false negative for `Rails/ReflectionClassName` when the
relation had a scope parameter.  The cop now considers relations with or
without the second optional scope parameter.

Before:

The following relation would not raise an offense even though the `class_name` parameter is a constant:

```ruby
belongs_to :account, -> { distinct }, class_name: Account
```

After:

The relations with an optional second scope parameter like the example above are now considered by the cop.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
