### PR TITLE
[Fix #341] Add EnforcedStyle to Rails/WhereExists to allow where(...).exists? to be the enforced style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [#310](https://github.com/rubocop-hq/rubocop-rails/issues/310): Add `EnforcedStyle` to `Rails/PluckInWhere`. By default, it does not register an offense if `pluck` method's receiver is a variable. ([@koic][])
 * [#320](https://github.com/rubocop-hq/rubocop-rails/pull/320): Mark `Rails/UniqBeforePluck` as unsafe auto-correction. ([@kunitoo][])
 * [#324](https://github.com/rubocop-hq/rubocop-rails/pull/324): Make `Rails/IndexBy` and `Rails/IndexWith` aware of `to_h` with block. ([@eugeneius][])
+* [#341](https://github.com/rubocop-hq/rubocop-rails/pull/341): Make `Rails/WhereExists` configurable to allow `where(...).exists?` to be the prefered style. ([@dvandersluis][])
 
 ## 2.7.1 (2020-07-26)
 
@@ -273,3 +274,4 @@
 [@jaredmoody]: https://github.com/jaredmoody
 [@mobilutz]: https://github.com/mobilutz
 [@bubaflub]: https://github.com/bubaflub
+[@dvandersluis]: https://github.com/dvandersluis

--- a/config/default.yml
+++ b/config/default.yml
@@ -708,7 +708,12 @@ Rails/Validation:
 Rails/WhereExists:
   Description: 'Prefer `exists?(...)` over `where(...).exists?`.'
   Enabled: 'pending'
+  EnforcedStyle: exists
+  SupportedStyles:
+    - exists
+    - where
   VersionAdded: '2.7'
+  VersionChanged: '2.8'
 
 Rails/WhereNot:
   Description: 'Use `where.not(...)` instead of manually constructing negated SQL in `where`.'

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -4293,12 +4293,20 @@ validates :foo, uniqueness: true
 | Yes
 | Yes
 | 2.7
-| -
+| 2.8
 |===
 
-This cop enforces the use of `exists?(...)` over `where(...).exists?`.
+This cop enforces consistent style when using `exists?`.
+
+Two styles are supported for this cop. When EnforcedStyle is 'exists'
+then the cop enforces `exists?(...)` over `where(...).exists?`.
+
+When EnforcedStyle is 'where' then the cop enforces
+`where(...).exists?` over `exists?(...)`.
 
 === Examples
+
+==== EnforcedStyle: exists (default)
 
 [source,ruby]
 ----
@@ -4313,6 +4321,34 @@ User.exists?(name: 'john')
 User.where('length(name) > 10').exists?
 user.posts.exists?(published: true)
 ----
+
+==== EnforcedStyle: where
+
+[source,ruby]
+----
+# bad
+User.exists?(name: 'john')
+User.exists?(['name = ?', 'john'])
+User.exists?('name = ?', 'john')
+user.posts.exists?(published: true)
+
+# good
+User.where(name: 'john').exists?
+User.where(['name = ?', 'john']).exists?
+User.where('name = ?', 'john').exists?
+user.posts.where(published: true).exists?
+User.where('length(name) > 10').exists?
+----
+
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| EnforcedStyle
+| `exists`
+| `exists`, `where`
+|===
 
 == Rails/WhereNot
 

--- a/lib/rubocop/cop/rails/where_exists.rb
+++ b/lib/rubocop/cop/rails/where_exists.rb
@@ -3,9 +3,15 @@
 module RuboCop
   module Cop
     module Rails
-      # This cop enforces the use of `exists?(...)` over `where(...).exists?`.
+      # This cop enforces consistent style when using `exists?`.
       #
-      # @example
+      # Two styles are supported for this cop. When EnforcedStyle is 'exists'
+      # then the cop enforces `exists?(...)` over `where(...).exists?`.
+      #
+      # When EnforcedStyle is 'where' then the cop enforces
+      # `where(...).exists?` over `exists?(...)`.
+      #
+      # @example EnforcedStyle: exists (default)
       #   # bad
       #   User.where(name: 'john').exists?
       #   User.where(['name = ?', 'john']).exists?
@@ -17,15 +23,34 @@ module RuboCop
       #   User.where('length(name) > 10').exists?
       #   user.posts.exists?(published: true)
       #
+      # @example EnforcedStyle: where
+      #   # bad
+      #   User.exists?(name: 'john')
+      #   User.exists?(['name = ?', 'john'])
+      #   User.exists?('name = ?', 'john')
+      #   user.posts.exists?(published: true)
+      #
+      #   # good
+      #   User.where(name: 'john').exists?
+      #   User.where(['name = ?', 'john']).exists?
+      #   User.where('name = ?', 'john').exists?
+      #   user.posts.where(published: true).exists?
+      #   User.where('length(name) > 10').exists?
       class WhereExists < Cop
+        include ConfigurableEnforcedStyle
+
         MSG = 'Prefer `%<good_method>s` over `%<bad_method>s`.'
 
         def_node_matcher :where_exists_call?, <<~PATTERN
           (send (send _ :where $...) :exists?)
         PATTERN
 
+        def_node_matcher :exists_with_args?, <<~PATTERN
+          (send _ :exists? $...)
+        PATTERN
+
         def on_send(node)
-          where_exists_call?(node) do |args|
+          find_offenses(node) do |args|
             return unless convertable_args?(args)
 
             range = correction_range(node)
@@ -35,7 +60,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          args = where_exists_call?(node)
+          args = find_offenses(node)
 
           lambda do |corrector|
             corrector.replace(
@@ -47,19 +72,57 @@ module RuboCop
 
         private
 
+        def where_style?
+          style == :where
+        end
+
+        def exists_style?
+          style == :exists
+        end
+
+        def find_offenses(node, &block)
+          if exists_style?
+            where_exists_call?(node, &block)
+          elsif where_style?
+            exists_with_args?(node, &block)
+          end
+        end
+
         def convertable_args?(args)
+          return false if args.empty?
+
           args.size > 1 || args[0].hash_type? || args[0].array_type?
         end
 
         def correction_range(node)
-          node.receiver.loc.selector.join(node.loc.selector)
+          if exists_style?
+            node.receiver.loc.selector.join(node.loc.selector)
+          elsif where_style?
+            node.loc.selector.with(end_pos: node.loc.expression.end_pos)
+          end
         end
 
         def build_good_method(args)
+          if exists_style?
+            build_good_method_exists(args)
+          elsif where_style?
+            build_good_method_where(args)
+          end
+        end
+
+        def build_good_method_exists(args)
           if args.size > 1
             "exists?([#{args.map(&:source).join(', ')}])"
           else
             "exists?(#{args[0].source})"
+          end
+        end
+
+        def build_good_method_where(args)
+          if args.size > 1
+            "where(#{args.map(&:source).join(', ')}).exists?"
+          else
+            "where(#{args[0].source}).exists?"
           end
         end
       end

--- a/spec/rubocop/cop/rails/where_exists_spec.rb
+++ b/spec/rubocop/cop/rails/where_exists_spec.rb
@@ -1,50 +1,161 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Rails::WhereExists do
-  subject(:cop) { described_class.new }
+RSpec.describe RuboCop::Cop::Rails::WhereExists, :config do
+  subject(:cop) { described_class.new(config) }
 
-  it 'registers an offense and corrects when using `where(...).exists?` with hash argument' do
-    expect_offense(<<~RUBY)
-      User.where(name: 'john').exists?
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `exists?(name: 'john')` over `where(name: 'john').exists?`.
-    RUBY
+  context 'when EnforcedStyle is "exists"' do
+    let(:cop_config) { { 'EnforcedStyle' => 'exists' } }
 
-    expect_correction(<<~RUBY)
-      User.exists?(name: 'john')
-    RUBY
+    it 'registers an offense and corrects when using `where(...).exists?` with hash argument' do
+      expect_offense(<<~RUBY)
+        User.where(name: 'john').exists?
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `exists?(name: 'john')` over `where(name: 'john').exists?`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        User.exists?(name: 'john')
+      RUBY
+    end
+
+    it 'registers an offense and corrects when using `where(...).exists?` with array argument' do
+      expect_offense(<<~RUBY)
+        User.where(['name = ?', 'john']).exists?
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `exists?(['name = ?', 'john'])` over `where(['name = ?', 'john']).exists?`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        User.exists?(['name = ?', 'john'])
+      RUBY
+    end
+
+    it 'registers an offense and corrects when using `where(...).exists?` with multiple arguments' do
+      expect_offense(<<~RUBY)
+        User.where('name = ?', 'john').exists?
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `exists?(['name = ?', 'john'])` over `where('name = ?', 'john').exists?`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        User.exists?(['name = ?', 'john'])
+      RUBY
+    end
+
+    it 'registers an offense when using `where(...).exists?` with an association' do
+      expect_offense(<<~RUBY)
+        user.posts.where(published: true).exists?
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `exists?(published: true)` over `where(published: true).exists?`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        user.posts.exists?(published: true)
+      RUBY
+    end
+
+    it 'does not register an offense when using `where(...).exists?` with string argument' do
+      expect_no_offenses(<<~RUBY)
+        User.where("name = 'john'").exists?
+      RUBY
+    end
+
+    it 'does not register an offense when using `exists?`' do
+      expect_no_offenses(<<~RUBY)
+        User.exists?(name: 'john')
+      RUBY
+    end
+
+    it 'does not register an offense when using `exists?` with no args' do
+      expect_no_offenses(<<~RUBY)
+        User.exists?
+      RUBY
+    end
+
+    it 'does not register an offense when using `exists?` with an association' do
+      expect_no_offenses(<<~RUBY)
+        user.posts.exists?(published: true)
+      RUBY
+    end
   end
 
-  it 'registers an offense and corrects when using `where(...).exists?` with array argument' do
-    expect_offense(<<~RUBY)
-      User.where(['name = ?', 'john']).exists?
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `exists?(['name = ?', 'john'])` over `where(['name = ?', 'john']).exists?`.
-    RUBY
+  context 'when EnforcedStyle is "where"' do
+    let(:cop_config) { { 'EnforcedStyle' => 'where' } }
 
-    expect_correction(<<~RUBY)
-      User.exists?(['name = ?', 'john'])
-    RUBY
-  end
+    it 'registers an offense and corrects when using `exists?` with a hash' do
+      expect_offense(<<~RUBY)
+        User.exists?(name: 'john')
+             ^^^^^^^^^^^^^^^^^^^^^ Prefer `where(name: 'john').exists?` over `exists?(name: 'john')`.
+      RUBY
 
-  it 'registers an offense and corrects when using `where(...).exists?` with multiple arguments' do
-    expect_offense(<<~RUBY)
-      User.where('name = ?', 'john').exists?
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `exists?(['name = ?', 'john'])` over `where('name = ?', 'john').exists?`.
-    RUBY
+      expect_correction(<<~RUBY)
+        User.where(name: 'john').exists?
+      RUBY
+    end
 
-    expect_correction(<<~RUBY)
-      User.exists?(['name = ?', 'john'])
-    RUBY
-  end
+    it 'registers an offense and corrects when using `exists?` with an array' do
+      expect_offense(<<~RUBY)
+        User.exists?(['name = ?', 'john'])
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `where(['name = ?', 'john']).exists?` over `exists?(['name = ?', 'john'])`.
+      RUBY
 
-  it 'does not register an offense when using `where(...).exists?` with string argument' do
-    expect_no_offenses(<<~RUBY)
-      User.where("name = 'john'").exists?
-    RUBY
-  end
+      expect_correction(<<~RUBY)
+        User.where(['name = ?', 'john']).exists?
+      RUBY
+    end
 
-  it 'does not register an offense when using `exists?`' do
-    expect_no_offenses(<<~RUBY)
-      User.exists?(name: 'john')
-    RUBY
+    it 'registers an offense and corrects when using `exists?` with an multiple arguments' do
+      expect_offense(<<~RUBY)
+        User.exists?('name = ?', 'john')
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `where('name = ?', 'john').exists?` over `exists?('name = ?', 'john')`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        User.where('name = ?', 'john').exists?
+      RUBY
+    end
+
+    it 'registers an offense and corrects when using `exists?` with an association' do
+      expect_offense(<<~RUBY)
+        user.posts.exists?(published: true)
+                   ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `where(published: true).exists?` over `exists?(published: true)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        user.posts.where(published: true).exists?
+      RUBY
+    end
+
+    it 'does not register an offense when using `where(...).exists?` with hash argument' do
+      expect_no_offenses(<<~RUBY)
+        User.where(name: 'john').exists?
+      RUBY
+    end
+
+    it 'does not register an offense when using `where(...).exists?` with array argument' do
+      expect_no_offenses(<<~RUBY)
+        User.where(['name = ?', 'john']).exists?
+      RUBY
+    end
+
+    it 'does not register an offense when using `where(...).exists?` with multiple arguments' do
+      expect_no_offenses(<<~RUBY)
+        User.where('name = ?', 'john').exists?
+      RUBY
+    end
+
+    it 'does not register an offense when using `where(...).exists?` with string argument' do
+      expect_no_offenses(<<~RUBY)
+        User.where("name = 'john'").exists?
+      RUBY
+    end
+
+    it 'does not register an offense when using `where(...).exists?` with an association' do
+      expect_no_offenses(<<~RUBY)
+        user.posts.where(published: true).exists?
+      RUBY
+    end
+
+    it 'does not register an offense when using `exists?` with no args' do
+      expect_no_offenses(<<~RUBY)
+        User.exists?
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Fixes #341.

Adds `EnforcedStyle` to `Rails/WhereExists` to allow the preferred style to be configurable. The previous preference of `exists?(...)` is retained as the default, but `EnforcedStyle: where` allows `where(...).exists?` to be prefered instead.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
