### PR TITLE
Fix a false positive for `Rails/DynamicFindBy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#338](https://github.com/rubocop-hq/rubocop-rails/issues/338): Fix a false positive for `Rails/IndexBy` and `Rails/IndexWith` when the `each_with_object` hash is used in the transformed key or value. ([@eugeneius][])
 * [#351](https://github.com/rubocop-hq/rubocop-rails/pull/351): Add `<>` operator to `Rails/WhereNot` cop. ([@Tietew][])
 * [#352](https://github.com/rubocop-hq/rubocop-rails/pull/352): Do not register offense if given a splatted hash. ([@dvandersluis][])
+* [#346](https://github.com/rubocop-hq/rubocop-rails/pull/346): Fix a false positive for `Rails/DynamicFindBy` when any of the arguments are splat argument. ([@koic][])
 
 ## 2.8.0 (2020-09-04)
 

--- a/lib/rubocop/cop/rails/dynamic_find_by.rb
+++ b/lib/rubocop/cop/rails/dynamic_find_by.rb
@@ -41,6 +41,7 @@ module RuboCop
           method_name = node.method_name
           static_name = static_method_name(method_name)
           return unless static_name
+          return if node.arguments.any?(&:splat_type?)
 
           add_offense(node,
                       message: format(MSG, static_name: static_name,

--- a/spec/rubocop/cop/rails/dynamic_find_by_spec.rb
+++ b/spec/rubocop/cop/rails/dynamic_find_by_spec.rb
@@ -133,6 +133,14 @@ RSpec.describe RuboCop::Cop::Rails::DynamicFindBy, :config do
     expect_no_offenses('User.find_by(name: name)')
   end
 
+  it 'accepts splat argument' do
+    expect_no_offenses('User.find_by_scan(*args)')
+  end
+
+  it 'accepts any of the arguments are splat argument' do
+    expect_no_offenses('User.find_by_foo_and_bar(arg, *args)')
+  end
+
   it 'accepts method in whitelist' do
     expect_no_offenses(<<~RUBY)
       User.find_by_sql(["select * from users where name = ?", name])


### PR DESCRIPTION
This PR fixes a false positive for `Rails/DynamicFindBy` when any of the arguments are splat argument.

```console
% cat example.rb
find_by_scan(*args)

% bundle exec rubocop -a example.rb
(snip)

Inspecting 1 file
E

Offenses:

example.rb:1:1: C: [Corrected] Rails/DynamicFindBy: Use find_by instead
of dynamic find_by_scan.
find_by_scan(*args)
^^^^^^^^^^^^^^^^^^^
example.rb:1:15: E: Lint/Syntax: unexpected token tSTAR
(Using Ruby 2.7 parser; configure using TargetRubyVersion parameter,
under AllCops)
find_by(scan: *args)
              ^

1 file inspected, 2 offenses detected, 1 offense corrected

% cat example.rb
find_by(scan: *args)

% ruby -c example.rb
example.rb:1: syntax error, unexpected *
find_by(scan: *args)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
