### PR TITLE
[Fix #345] Fix error of `Rails/AfterCommitOverride` on `after_commit`with a lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#345](https://github.com/rubocop-hq/rubocop-rails/issues/345): Fix error of `Rails/AfterCommitOverride` on `after_commit` with a lambda. ([@pocke][])
+
 ## 2.8.0 (2020-09-04)
 
 ### New features

--- a/lib/rubocop/cop/rails/after_commit_override.rb
+++ b/lib/rubocop/cop/rails/after_commit_override.rb
@@ -59,7 +59,7 @@ module RuboCop
 
         def each_after_commit_callback(class_node)
           class_send_nodes(class_node).each do |node|
-            yield node if after_commit_callback?(node)
+            yield node if after_commit_callback?(node) && named_callback?(node)
           end
         end
 
@@ -77,6 +77,13 @@ module RuboCop
 
         def after_commit_callback?(node)
           AFTER_COMMIT_CALLBACKS.include?(node.method_name)
+        end
+
+        def named_callback?(node)
+          name = node.first_argument
+          return false unless name
+
+          name.sym_type?
         end
       end
     end

--- a/spec/rubocop/cop/rails/after_commit_override_spec.rb
+++ b/spec/rubocop/cop/rails/after_commit_override_spec.rb
@@ -32,4 +32,22 @@ RSpec.describe RuboCop::Cop::Rails::AfterCommitOverride do
       end
     RUBY
   end
+
+  it 'does not register an offense when the callbacks are defined with lambdas' do
+    expect_no_offenses(<<~RUBY)
+      class User < ApplicationRecord
+        after_commit -> { foo }
+        after_destroy_commit -> { foo }
+      end
+    RUBY
+  end
+
+  it 'ignores after_commit method call without arguments' do
+    expect_no_offenses(<<~RUBY)
+      class User < ApplicationRecord
+        after_commit
+        after_destroy_commit
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #345 


I got the same error on our Rails project, and I've confirmed the error is fixed by this patch. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
