### PR TITLE
Fix errors of `Rails/UniqueValidationWithoutIndex`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#345](https://github.com/rubocop-hq/rubocop-rails/issues/345): Fix error of `Rails/AfterCommitOverride` on `after_commit` with a lambda. ([@pocke][])
+* [#349](https://github.com/rubocop-hq/rubocop-rails/pull/349): Fix errors of `Rails/UniqueValidationWithoutIndex`. ([@Tietew][])
 
 ## 2.8.0 (2020-09-04)
 
@@ -281,3 +282,4 @@
 [@mobilutz]: https://github.com/mobilutz
 [@bubaflub]: https://github.com/bubaflub
 [@dvandersluis]: https://github.com/dvandersluis
+[@Tietew]: https://github.com/Tietew

--- a/lib/rubocop/cop/mixin/active_record_helper.rb
+++ b/lib/rubocop/cop/mixin/active_record_helper.rb
@@ -52,6 +52,7 @@ module RuboCop
       # @param table [RuboCop::Rails::SchemaLoader::Table]
       # @return [String, nil]
       def resolve_relation_into_column(name:, class_node:, table:)
+        return unless table
         return name if table.with_column?(name: name)
 
         find_belongs_to(class_node) do |belongs_to|

--- a/lib/rubocop/cop/rails/unique_validation_without_index.rb
+++ b/lib/rubocop/cop/rails/unique_validation_without_index.rb
@@ -46,6 +46,8 @@ module RuboCop
 
         def find_schema_information(node)
           klass = class_node(node)
+          return unless klass
+
           table = schema.table_by(name: table_name(klass))
           names = column_names(node)
 

--- a/spec/rubocop/cop/rails/unique_validation_without_index_spec.rb
+++ b/spec/rubocop/cop/rails/unique_validation_without_index_spec.rb
@@ -495,5 +495,44 @@ RSpec.describe RuboCop::Cop::Rails::UniqueValidationWithoutIndex, :config do
         end
       end
     end
+
+    context 'when the table does not exist' do
+      let(:schema) { <<~RUBY }
+        ActiveRecord::Schema.define(version: 2020_02_02_075409) do
+          create_table "users", force: :cascade do |t|
+            t.string "account", null: false, unique: true
+          end
+        end
+      RUBY
+
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          class Article
+            validates :account, uniqueness: true
+          end
+        RUBY
+      end
+    end
+
+    context 'when module' do
+      let(:schema) { <<~RUBY }
+        ActiveRecord::Schema.define(version: 2020_02_02_075409) do
+          create_table "users", force: :cascade do |t|
+            t.string "account", null: false, unique: true
+          end
+        end
+      RUBY
+
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          module User
+            extend ActiveSupport::Concern
+            included do
+              validates :account, uniqueness: true
+            end
+          end
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
`Rails/UniqueValidationWithoutIndex` dies with following error:

When the table does not exist:
```
An error occurred while Rails/UniqueValidationWithoutIndex cop was inspecting <filename>.
undefined method `each_node' for nil:NilClass
.../lib/rubocop/cop/mixin/active_record_helper.rb:14:in `find_set_table_name'
```

When defining `module` instead of `class`:
```
An error occurred while Rails/UniqueValidationWithoutIndex cop was inspecting <filename>.
undefined method `with_column?' for nil:NilClass
.../lib/rubocop/cop/mixin/active_record_helper.rb:55:in `resolve_relation_into_column'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
