### PR TITLE
Add `<>` operator to `Rails/WhereNot` cop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#345](https://github.com/rubocop-hq/rubocop-rails/issues/345): Fix error of `Rails/AfterCommitOverride` on `after_commit` with a lambda. ([@pocke][])
 * [#349](https://github.com/rubocop-hq/rubocop-rails/pull/349): Fix errors of `Rails/UniqueValidationWithoutIndex`. ([@Tietew][])
 * [#338](https://github.com/rubocop-hq/rubocop-rails/issues/338): Fix a false positive for `Rails/IndexBy` and `Rails/IndexWith` when the `each_with_object` hash is used in the transformed key or value. ([@eugeneius][])
+* [#351](https://github.com/rubocop-hq/rubocop-rails/pull/351): Add `<>` operator to `Rails/WhereNot` cop. ([@Tietew][])
 
 ## 2.8.0 (2020-09-04)
 

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -4372,6 +4372,8 @@ in `where` can be replaced with `where.not(...)`.
 # bad
 User.where('name != ?', 'Gabe')
 User.where('name != :name', name: 'Gabe')
+User.where('name <> ?', 'Gabe')
+User.where('name <> :name', name: 'Gabe')
 User.where('name IS NOT NULL')
 User.where('name NOT IN (?)', ['john', 'jane'])
 User.where('name NOT IN (:names)', names: ['john', 'jane'])

--- a/lib/rubocop/cop/rails/where_not.rb
+++ b/lib/rubocop/cop/rails/where_not.rb
@@ -10,6 +10,8 @@ module RuboCop
       #   # bad
       #   User.where('name != ?', 'Gabe')
       #   User.where('name != :name', name: 'Gabe')
+      #   User.where('name <> ?', 'Gabe')
+      #   User.where('name <> :name', name: 'Gabe')
       #   User.where('name IS NOT NULL')
       #   User.where('name NOT IN (?)', ['john', 'jane'])
       #   User.where('name NOT IN (:names)', names: ['john', 'jane'])
@@ -62,9 +64,9 @@ module RuboCop
           end
         end
 
-        NOT_EQ_ANONYMOUS_RE = /\A([\w.]+)\s+!=\s+\?\z/.freeze                  # column != ?
+        NOT_EQ_ANONYMOUS_RE = /\A([\w.]+)\s+(?:!=|<>)\s+\?\z/.freeze           # column != ?, column <> ?
         NOT_IN_ANONYMOUS_RE = /\A([\w.]+)\s+NOT\s+IN\s+\(\?\)\z/i.freeze       # column NOT IN (?)
-        NOT_EQ_NAMED_RE     = /\A([\w.]+)\s+!=\s+:(\w+)\z/.freeze              # column != :column
+        NOT_EQ_NAMED_RE     = /\A([\w.]+)\s+(?:!=|<>)\s+:(\w+)\z/.freeze       # column != :column, column <> :column
         NOT_IN_NAMED_RE     = /\A([\w.]+)\s+NOT\s+IN\s+\(:(\w+)\)\z/i.freeze   # column NOT IN (:column)
         IS_NOT_NULL_RE      = /\A([\w.]+)\s+IS\s+NOT\s+NULL\z/i.freeze         # column IS NOT NULL
 

--- a/spec/rubocop/cop/rails/where_not_spec.rb
+++ b/spec/rubocop/cop/rails/where_not_spec.rb
@@ -25,6 +25,28 @@ RSpec.describe RuboCop::Cop::Rails::WhereNot do
     RUBY
   end
 
+  it 'registers an offense and corrects when using `<>` and anonymous placeholder' do
+    expect_offense(<<~RUBY)
+      User.where('name <> ?', 'Gabe')
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `where.not(name: 'Gabe')` instead of manually constructing negated SQL in `where`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      User.where.not(name: 'Gabe')
+    RUBY
+  end
+
+  it 'registers an offense and corrects when using `<>` and named placeholder' do
+    expect_offense(<<~RUBY)
+      User.where('name <> :name', name: 'Gabe')
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `where.not(name: 'Gabe')` instead of manually constructing negated SQL in `where`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      User.where.not(name: 'Gabe')
+    RUBY
+  end
+
   it 'registers an offense and corrects when using `IS NOT NULL`' do
     expect_offense(<<~RUBY)
       User.where('name IS NOT NULL')
@@ -58,9 +80,20 @@ RSpec.describe RuboCop::Cop::Rails::WhereNot do
     RUBY
   end
 
-  it 'registers an offense and corrects when using namespaced columns' do
+  it 'registers an offense and corrects when using `!=` and namespaced columns' do
     expect_offense(<<~RUBY)
       Course.where('enrollments.student_id != ?', student.id)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `where.not('enrollments.student_id' => student.id)` instead of manually constructing negated SQL in `where`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Course.where.not('enrollments.student_id' => student.id)
+    RUBY
+  end
+
+  it 'registers an offense and corrects when using `<>` and namespaced columns' do
+    expect_offense(<<~RUBY)
+      Course.where('enrollments.student_id <> ?', student.id)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `where.not('enrollments.student_id' => student.id)` instead of manually constructing negated SQL in `where`.
     RUBY
 
@@ -84,6 +117,28 @@ RSpec.describe RuboCop::Cop::Rails::WhereNot do
     it 'registers an offense and corrects when using `!=` and named placeholder' do
       expect_offense(<<~RUBY)
         User.where(['name != :name', { name: 'Gabe' }])
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `where.not(name: 'Gabe')` instead of manually constructing negated SQL in `where`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        User.where.not(name: 'Gabe')
+      RUBY
+    end
+
+    it 'registers an offense and corrects when using `<>` and anonymous placeholder' do
+      expect_offense(<<~RUBY)
+        User.where(['name <> ?', 'Gabe'])
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `where.not(name: 'Gabe')` instead of manually constructing negated SQL in `where`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        User.where.not(name: 'Gabe')
+      RUBY
+    end
+
+    it 'registers an offense and corrects when using `<>` and named placeholder' do
+      expect_offense(<<~RUBY)
+        User.where(['name <> :name', { name: 'Gabe' }])
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `where.not(name: 'Gabe')` instead of manually constructing negated SQL in `where`.
       RUBY
 
@@ -125,9 +180,20 @@ RSpec.describe RuboCop::Cop::Rails::WhereNot do
       RUBY
     end
 
-    it 'registers an offense and corrects when using namespaced columns' do
+    it 'registers an offense and corrects when using `!=` and namespaced columns' do
       expect_offense(<<~RUBY)
         Course.where(['enrollments.student_id != ?', student.id])
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `where.not('enrollments.student_id' => student.id)` instead of manually constructing negated SQL in `where`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Course.where.not('enrollments.student_id' => student.id)
+      RUBY
+    end
+
+    it 'registers an offense and corrects when using `<>` and namespaced columns' do
+      expect_offense(<<~RUBY)
+        Course.where(['enrollments.student_id <> ?', student.id])
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `where.not('enrollments.student_id' => student.id)` instead of manually constructing negated SQL in `where`.
       RUBY
 
@@ -155,9 +221,15 @@ RSpec.describe RuboCop::Cop::Rails::WhereNot do
     RUBY
   end
 
-  it 'does not register an offense when template string contains negation and additional boolean logic' do
+  it 'does not register an offense when template string contains `!=` and additional boolean logic' do
     expect_no_offenses(<<~RUBY)
       User.where('name != ? AND age != ?', 'john', 19)
+    RUBY
+  end
+
+  it 'does not register an offense when template string contains `<>` and additional boolean logic' do
+    expect_no_offenses(<<~RUBY)
+      User.where('name <> ? AND age <> ?', 'john', 19)
     RUBY
   end
 end


### PR DESCRIPTION
SQL standard defines `<>` as not-equal operator. `!=` is a de facto standard.

cf. https://www.postgresql.org/docs/12/functions-comparison.html
(I'm afraid I have no pointer to SQL standard documentation.)

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
