### PR TITLE
[Fix #338][Fix #350] Fix a false positive for Rails/IndexBy and Rails/IndexWith

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#345](https://github.com/rubocop-hq/rubocop-rails/issues/345): Fix error of `Rails/AfterCommitOverride` on `after_commit` with a lambda. ([@pocke][])
 * [#349](https://github.com/rubocop-hq/rubocop-rails/pull/349): Fix errors of `Rails/UniqueValidationWithoutIndex`. ([@Tietew][])
+* [#338](https://github.com/rubocop-hq/rubocop-rails/issues/338): Fix a false positive for `Rails/IndexBy` and `Rails/IndexWith` when the `each_with_object` hash is used in the transformed key or value. ([@eugeneius][])
 
 ## 2.8.0 (2020-09-04)
 

--- a/lib/rubocop/cop/rails/index_by.rb
+++ b/lib/rubocop/cop/rails/index_by.rb
@@ -24,7 +24,7 @@ module RuboCop
           (block
             ({send csend} _ :each_with_object (hash))
             (args (arg $_el) (arg _memo))
-            ({send csend} (lvar _memo) :[]= $_ (lvar _el)))
+            ({send csend} (lvar _memo) :[]= $!`_memo (lvar _el)))
         PATTERN
 
         def_node_matcher :on_bad_to_h, <<~PATTERN

--- a/lib/rubocop/cop/rails/index_with.rb
+++ b/lib/rubocop/cop/rails/index_with.rb
@@ -27,7 +27,7 @@ module RuboCop
           (block
             ({send csend} _ :each_with_object (hash))
             (args (arg $_el) (arg _memo))
-            ({send csend} (lvar _memo) :[]= (lvar _el) $_))
+            ({send csend} (lvar _memo) :[]= (lvar _el) $!`_memo))
         PATTERN
 
         def_node_matcher :on_bad_to_h, <<~PATTERN

--- a/spec/rubocop/cop/rails/index_by_spec.rb
+++ b/spec/rubocop/cop/rails/index_by_spec.rb
@@ -68,6 +68,14 @@ RSpec.describe RuboCop::Cop::Rails::IndexBy, :config do
     end
   end
 
+  context 'when the given hash is used in the key' do
+    it 'does not register an offense for `each_with_object`' do
+      expect_no_offenses(<<~RUBY)
+        x.each_with_object({}) { |el, h| h[h[el]] = el }
+      RUBY
+    end
+  end
+
   context 'when `to_h` is given a block' do
     it 'registers an offense for `map { ... }.to_h`' do
       expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/rails/index_with_spec.rb
+++ b/spec/rubocop/cop/rails/index_with_spec.rb
@@ -69,6 +69,14 @@ RSpec.describe RuboCop::Cop::Rails::IndexWith, :config do
       end
     end
 
+    context 'when the given hash is used in the value' do
+      it 'does not register an offense for `each_with_object`' do
+        expect_no_offenses(<<~RUBY)
+          x.each_with_object({}) { |el, h| h[el] = h.count }
+        RUBY
+      end
+    end
+
     context 'when `to_h` is given a block' do
       it 'registers an offense for `map { ... }.to_h`' do
         expect_offense(<<~RUBY)


### PR DESCRIPTION
If the `each_with_object` hash is used in the transformed key or value, `Rails/IndexBy` or `Rails/IndexWith` can't be used.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/