### PR TITLE
[Fix #352] Do not register an offense for `Rails/HttpPositionalArguments` when given a splatted hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#349](https://github.com/rubocop-hq/rubocop-rails/pull/349): Fix errors of `Rails/UniqueValidationWithoutIndex`. ([@Tietew][])
 * [#338](https://github.com/rubocop-hq/rubocop-rails/issues/338): Fix a false positive for `Rails/IndexBy` and `Rails/IndexWith` when the `each_with_object` hash is used in the transformed key or value. ([@eugeneius][])
 * [#351](https://github.com/rubocop-hq/rubocop-rails/pull/351): Add `<>` operator to `Rails/WhereNot` cop. ([@Tietew][])
+* [#352](https://github.com/rubocop-hq/rubocop-rails/pull/352): Do not register offense if given a splatted hash. ([@dvandersluis][])
 
 ## 2.8.0 (2020-09-04)
 

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -1550,6 +1550,7 @@ get :new, { user_id: 1}
 
 # good
 get :new, params: { user_id: 1 }
+get :new, **options
 ----
 
 === Configurable attributes

--- a/lib/rubocop/cop/rails/http_positional_arguments.rb
+++ b/lib/rubocop/cop/rails/http_positional_arguments.rb
@@ -16,6 +16,7 @@ module RuboCop
       #
       #   # good
       #   get :new, params: { user_id: 1 }
+      #   get :new, **options
       class HttpPositionalArguments < Cop
         extend TargetRailsVersion
 
@@ -30,6 +31,10 @@ module RuboCop
 
         def_node_matcher :http_request?, <<~PATTERN
           (send nil? {#{HTTP_METHODS.map(&:inspect).join(' ')}} !nil? $_ ...)
+        PATTERN
+
+        def_node_matcher :kwsplat_hash?, <<~PATTERN
+          (hash (kwsplat _))
         PATTERN
 
         def on_send(node)
@@ -61,6 +66,7 @@ module RuboCop
 
         def needs_conversion?(data)
           return true unless data.hash_type?
+          return false if kwsplat_hash?(data)
 
           data.each_pair.none? do |pair|
             special_keyword_arg?(pair.key) ||

--- a/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
+++ b/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
@@ -411,5 +411,16 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
         post user_attrs, params: params.merge(foo: bar)
       RUBY
     end
+
+    context 'when given a kwsplat hash' do
+      # See https://github.com/rubocop-hq/rubocop-rails/issues/352
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          [{ format: :json }, { format: :html }].each do |args|
+            get :nothing, **args
+          end
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
The following code will no longer register an offense:

```ruby
[{ format: :json }, { format: :html }].each do |args|
  get :nothing, **args
end
```

Fixes #352.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
