### PR TITLE
Suppress RuboCop's offense

### DIFF
--- a/spec/rubocop/cop/active_record_helper_spec.rb
+++ b/spec/rubocop/cop/active_record_helper_spec.rb
@@ -3,16 +3,8 @@
 RSpec.describe RuboCop::Cop::ActiveRecordHelper, :isolated_environment do
   include FileHelper
 
-  module RuboCop
-    module Cop
-      class Example < Cop
-        include ActiveRecordHelper
-      end
-    end
-  end
-
   let(:cop) do
-    RuboCop::Cop::Example.new
+    Class.new.extend RuboCop::Cop::ActiveRecordHelper
   end
 
   let(:schema_path) { 'db/schema.rb' }


### PR DESCRIPTION
Follow https://github.com/rubocop-hq/rubocop/pull/8707

This PR suppresses the following RuboCop's offense.

```console
% bundle exec rake
(snip)

Offenses:

spec/rubocop/cop/active_record_helper_spec.rb:6:3: W:
Lint/ConstantDefinitionInBlock: Do not define constants within a block.
  module RuboCop ...
    ^^^^^^^^^^^^^^

185 files inspected, 1 offense detected, 1 offense auto-correctable
RuboCop failed!
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
