### PR TITLE
[Fix #357] Fix a false positive for `Rails/ReversibleMigration`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#351](https://github.com/rubocop-hq/rubocop-rails/pull/351): Add `<>` operator to `Rails/WhereNot` cop. ([@Tietew][])
 * [#352](https://github.com/rubocop-hq/rubocop-rails/pull/352): Do not register offense if given a splatted hash. ([@dvandersluis][])
 * [#346](https://github.com/rubocop-hq/rubocop-rails/pull/346): Fix a false positive for `Rails/DynamicFindBy` when any of the arguments are splat argument. ([@koic][])
+* [#357](https://github.com/rubocop-hq/rubocop-rails/issues/357): Fix a false positive for `Rails/ReversibleMigration` when keyword arguments of `change_column_default` are in the order of `to`, `from`. ([@koic][])
 
 ## 2.8.0 (2020-09-04)
 

--- a/lib/rubocop/cop/rails/reversible_migration.rb
+++ b/lib/rubocop/cop/rails/reversible_migration.rb
@@ -360,7 +360,7 @@ module RuboCop
             key.children.first.to_sym
           end
 
-          hash_keys & keys == keys
+          (hash_keys & keys).sort == keys
         end
       end
     end

--- a/spec/rubocop/cop/rails/reversible_migration_spec.rb
+++ b/spec/rubocop/cop/rails/reversible_migration_spec.rb
@@ -115,6 +115,11 @@ RSpec.describe RuboCop::Cop::Rails::ReversibleMigration, :config do
     RUBY
 
     it_behaves_like 'accepts',
+                    'change_column_default(with :to and :from)', <<-RUBY
+      change_column_default(:posts, :state, to: "draft", from: nil)
+    RUBY
+
+    it_behaves_like 'accepts',
                     'change_column_default(*column :from and :to)', <<-RUBY
       columns = [:foo, :bar]
       change_column_default(*columns, from: nil, to: "draft")


### PR DESCRIPTION
Fixes #357.

This PR fixes a false positive for `Rails/ReversibleMigration` when keyword arguments of `change_column_default` are in the
order of `to`, `from`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
