### PR TITLE
Add Support for classes defined with compact style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#362](https://github.com/rubocop-hq/rubocop-rails/pull/362): Add new `Rails/WhereEquals` cop. ([@eugeneius][])
 
+### Bug fixes
+
+* [#364](https://github.com/rubocop-hq/rubocop-rails/pull/364): Fix a problem that `Rails/UniqueValidationWithoutIndex` doesn't work in classes defined with compact style. ([@sinsoku][])
+
 ## 2.8.1 (2020-09-16)
 
 ### Bug fixes

--- a/lib/rubocop/cop/mixin/active_record_helper.rb
+++ b/lib/rubocop/cop/mixin/active_record_helper.rb
@@ -35,10 +35,11 @@ module RuboCop
         table_name = find_set_table_name(class_node).to_a.last&.first_argument
         return table_name.value.to_s if table_name
 
-        namespaces = class_node.each_ancestor(:class, :module)
-        [class_node, *namespaces]
+        class_nodes = class_node.defined_module.each_node
+        namespaces = class_node.each_ancestor(:class, :module).map(&:identifier)
+        [*class_nodes, *namespaces]
           .reverse
-          .map { |klass| klass.identifier.children[1] }.join('_')
+          .map { |node| node.children[1] }.join('_')
           .tableize
       end
 

--- a/spec/rubocop/cop/active_record_helper_spec.rb
+++ b/spec/rubocop/cop/active_record_helper_spec.rb
@@ -36,4 +36,60 @@ RSpec.describe RuboCop::Cop::ActiveRecordHelper, :isolated_environment do
       it { is_expected.to be_nil }
     end
   end
+
+  describe '#table_name' do
+    subject { cop.table_name(class_node) }
+
+    context 'when the class is simple' do
+      let(:class_node) { parse_source(<<~RUBY).ast }
+        class User
+        end
+      RUBY
+
+      it { is_expected.to eq 'users' }
+    end
+
+    context 'when the self.table_name is set' do
+      let(:class_node) { parse_source(<<~RUBY).ast }
+        class Foo
+          self.table_name = 'bar'
+        end
+      RUBY
+
+      it { is_expected.to eq 'bar' }
+    end
+
+    context 'when the class is defined in a module' do
+      let(:class_node) { parse_source(<<~RUBY).ast.each_child_node(:class).first }
+        module Admin
+          class User
+          end
+        end
+      RUBY
+
+      it { is_expected.to eq 'admin_users' }
+    end
+
+    context 'when the class is defined in nested modules' do
+      let(:class_node) { parse_source(<<~RUBY).ast.each_descendant(:class).first }
+        module Cop
+          module Admin
+            class User
+            end
+          end
+        end
+      RUBY
+
+      it { is_expected.to eq 'cop_admin_users' }
+    end
+
+    context 'when the class is defined with compact style' do
+      let(:class_node) { parse_source(<<~RUBY).ast }
+        class Cop::Admin::User
+        end
+      RUBY
+
+      it { is_expected.to eq 'cop_admin_users' }
+    end
+  end
 end

--- a/spec/rubocop/cop/rails/unique_validation_without_index_spec.rb
+++ b/spec/rubocop/cop/rails/unique_validation_without_index_spec.rb
@@ -393,7 +393,7 @@ RSpec.describe RuboCop::Cop::Rails::UniqueValidationWithoutIndex, :config do
       end
     end
 
-    context 'with nested class' do
+    context 'with namespaced model' do
       let(:schema) { <<~RUBY }
         ActiveRecord::Schema.define(version: 2020_02_02_075409) do
           create_table "admin_users", force: :cascade do |t|
@@ -402,13 +402,22 @@ RSpec.describe RuboCop::Cop::Rails::UniqueValidationWithoutIndex, :config do
         end
       RUBY
 
-      it 'registers an offense' do
+      it 'registers an offense for nested class' do
         expect_offense(<<~RUBY)
           module Admin
             class User
               validates :account, uniqueness: true
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Uniqueness validation should be with a unique index.
             end
+          end
+        RUBY
+      end
+
+      it 'registers an offense for compact styled class' do
+        expect_offense(<<~RUBY)
+          class Admin::User
+            validates :account, uniqueness: true
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Uniqueness validation should be with a unique index.
           end
         RUBY
       end


### PR DESCRIPTION
There is a problem that `Rails/UniqueValidationWithoutIndex` doesn't work
because it can't find the table name in the class defined with compact style.

This commit adds test code to ensure existing behavior and adds support for
classes defined with compact style.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
