### PR TITLE
[Fix #365] Mark `Rails/SquishedSQLHeredocs` unsafe for autocorrection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Changes
 
 * [#383](https://github.com/rubocop-hq/rubocop-rails/pull/383): Require RuboCop 0.90 or higher. ([@koic][])
+* [#365](https://github.com/rubocop-hq/rubocop-rails/issues/365): Mark `Rails/SquishedSQLHeredocs` unsafe for autocorrection. ([@tejasbubane][])
 
 ## 2.8.1 (2020-09-16)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -668,6 +668,10 @@ Rails/SquishedSQLHeredocs:
   StyleGuide: 'https://rails.rubystyle.guide/#squished-heredocs'
   Enabled: 'pending'
   VersionAdded: '2.8'
+  VersionChanged: '2.9'
+  # Some SQL syntax (e.g. PostgreSQL comments and functions) requires newlines
+  # to be preserved in order to work, thus auto-correction is not safe.
+  SafeAutoCorrect: false
 
 Rails/TimeZone:
   Description: 'Checks the correct usage of time zone aware methods.'

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -4056,12 +4056,14 @@ user.touch
 
 | Pending
 | Yes
-| Yes
+| Yes (Unsafe)
 | 2.8
-| -
+| 2.9
 |===
 
 Checks SQL heredocs to use `.squish`.
+Some SQL syntax (e.g. PostgreSQL comments and functions) requires newlines
+to be preserved in order to work, thus auto-correction for this cop is not safe.
 
 === Examples
 

--- a/lib/rubocop/cop/rails/squished_sql_heredocs.rb
+++ b/lib/rubocop/cop/rails/squished_sql_heredocs.rb
@@ -5,6 +5,8 @@ module RuboCop
     module Rails
       #
       # Checks SQL heredocs to use `.squish`.
+      # Some SQL syntax (e.g. PostgreSQL comments and functions) requires newlines
+      # to be preserved in order to work, thus auto-correction for this cop is not safe.
       #
       # @example
       #   # bad


### PR DESCRIPTION
Closes #365

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/