### PR TITLE
Add array and hash literal offenders to AttributeDefaultBlockValue

### DIFF
--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -452,8 +452,9 @@ assert_not x
 |===
 
 This cop looks for `attribute` class methods that specify a `:default` option
-which value is a method call without a block.
-It will accept all other values, such as literals and constants.
+which value is an array, string literal or method call without a block.
+It will accept all other values, such as string, symbol, integer and float literals
+as well as constants.
 
 === Examples
 
@@ -465,27 +466,47 @@ class User < ApplicationRecord
 end
 
 # good
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   attribute :confirmed_at, :datetime, default: -> { Time.zone.now }
 end
 
+# bad
+class User < ApplicationRecord
+  attribute :roles, :string, array: true, default: []
+end
+
 # good
-class User < ActiveRecord::Base
+class User < ApplicationRecord
+  attribute :roles, :string, array: true, default: -> { [] }
+end
+
+# bad
+class User < ApplicationRecord
+  attribute :configuration, default: {}
+end
+
+# good
+class User < ApplicationRecord
+  attribute :configuration, default: -> { {} }
+end
+
+# good
+class User < ApplicationRecord
   attribute :role, :string, default: :customer
 end
 
 # good
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   attribute :activated, :boolean, default: false
 end
 
 # good
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   attribute :login_count, :integer, default: 0
 end
 
 # good
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   FOO = 123
   attribute :custom_attribute, :integer, default: FOO
 end

--- a/lib/rubocop/cop/rails/attribute_default_block_value.rb
+++ b/lib/rubocop/cop/rails/attribute_default_block_value.rb
@@ -4,8 +4,9 @@ module RuboCop
   module Cop
     module Rails
       # This cop looks for `attribute` class methods that specify a `:default` option
-      # which value is a method call without a block.
-      # It will accept all other values, such as literals and constants.
+      # which value is an array, string literal or method call without a block.
+      # It will accept all other values, such as string, symbol, integer and float literals
+      # as well as constants.
       #
       # @example
       #   # bad
@@ -14,35 +15,56 @@ module RuboCop
       #   end
       #
       #   # good
-      #   class User < ActiveRecord::Base
+      #   class User < ApplicationRecord
       #     attribute :confirmed_at, :datetime, default: -> { Time.zone.now }
       #   end
       #
+      #   # bad
+      #   class User < ApplicationRecord
+      #     attribute :roles, :string, array: true, default: []
+      #   end
+      #
       #   # good
-      #   class User < ActiveRecord::Base
+      #   class User < ApplicationRecord
+      #     attribute :roles, :string, array: true, default: -> { [] }
+      #   end
+      #
+      #   # bad
+      #   class User < ApplicationRecord
+      #     attribute :configuration, default: {}
+      #   end
+      #
+      #   # good
+      #   class User < ApplicationRecord
+      #     attribute :configuration, default: -> { {} }
+      #   end
+      #
+      #   # good
+      #   class User < ApplicationRecord
       #     attribute :role, :string, default: :customer
       #   end
       #
       #   # good
-      #   class User < ActiveRecord::Base
+      #   class User < ApplicationRecord
       #     attribute :activated, :boolean, default: false
       #   end
       #
       #   # good
-      #   class User < ActiveRecord::Base
+      #   class User < ApplicationRecord
       #     attribute :login_count, :integer, default: 0
       #   end
       #
       #   # good
-      #   class User < ActiveRecord::Base
+      #   class User < ApplicationRecord
       #     FOO = 123
       #     attribute :custom_attribute, :integer, default: FOO
       #   end
       class AttributeDefaultBlockValue < Cop
         MSG = 'Pass method in a block to `:default` option.'
+        TYPE_OFFENDERS = %i[send array hash].freeze
 
         def_node_matcher :default_attribute, <<~PATTERN
-          (send nil? :attribute _ _ (hash <$#attribute ...>))
+          (send nil? :attribute _ ?_ (hash <$#attribute ...>))
         PATTERN
 
         def_node_matcher :attribute, '(pair (sym :default) $_)'
@@ -50,8 +72,9 @@ module RuboCop
         def on_send(node)
           default_attribute(node) do |attribute|
             value = attribute.children.last
+            return unless TYPE_OFFENDERS.any? { |type| value.type == type }
 
-            add_offense(node, location: value) if value.send_type?
+            add_offense(node, location: value)
           end
         end
 

--- a/spec/rubocop/cop/rails/attribute_default_block_value_spec.rb
+++ b/spec/rubocop/cop/rails/attribute_default_block_value_spec.rb
@@ -24,6 +24,20 @@ RSpec.describe RuboCop::Cop::Rails::AttributeDefaultBlockValue do
       RUBY
     end
 
+    it 'disallows array literals' do
+      expect_offense(<<~RUBY)
+        attribute :foo, :string, array: true, default: []
+                                                       ^^ #{message}
+      RUBY
+    end
+
+    it 'disallows hash literals' do
+      expect_offense(<<~RUBY)
+        attribute :foo, default: {}
+                                 ^^ #{message}
+      RUBY
+    end
+
     it 'autocorrects `:default` method value in same row' do
       expect_offense(<<~RUBY)
         attribute :foo, :string, default: Foo.bar


### PR DESCRIPTION
The [Attributes API](https://api.rubyonrails.org/classes/ActiveRecord/Attributes/ClassMethods.html#method-i-attribute) also allows defining attributes that are arrays or hashes.

```ruby
#   # bad
#   class User < ApplicationRecord
#     attribute :roles, :string, array: true, default: []
#   end
#
#   # good
#   class User < ActiveRecord::Base
#     attribute :roles, :string, array: true, default: -> { [] }
#   end
# 
#   bad
#   class User < ApplicationRecord
#     attribute :configuration, default: {}
#   end
#
#   # good
#   class User < ActiveRecord::Base
#     attribute :configuration, default: -> { {} }
#   end
```

This PR patches up the `AttributeDefaultBlockValue` cop accordingly.

Reason why array and hash literals should also be passed as a block is the fact that defining them without one creates a class attribute, not instance.

```ruby
class Simple < ActiveType::Object
  attribute :mutable_attribute, default: {}
end
```

```bash
[1] pry(main)> first = Simple.new
=> #<Simple mutable_attribute: {}>
[2] pry(main)> first.mutable_attribute.merge!(a: 3)
=> {:a=>3}
[3] pry(main)> second = Simple.new
=> #<Simple mutable_attribute: {:a=>3}>
[4] pry(main)> second.mutable_attribute
=> {:a=>3}
[5] pry(main)> Simple.new.mutable_attribute.object_id
=> 70340537951880
[6] pry(main)> Simple.new.mutable_attribute.object_id
=> 70340537951880
```

which is probably not what you want.