### PR TITLE
Fix an infinite loop error for `Rails/ActiveRecordCallbacksOrder` when callbacks have inline comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bug fixes
 
+* [#371](https://github.com/rubocop-hq/rubocop-rails/pull/371): Fix an infinite loop error for `Rails/ActiveRecordCallbacksOrder` when callbacks have inline comments. ([@fatkodima][])
 * [#364](https://github.com/rubocop-hq/rubocop-rails/pull/364): Fix a problem that `Rails/UniqueValidationWithoutIndex` doesn't work in classes defined with compact style. ([@sinsoku][])
 
 ## 2.8.1 (2020-09-16)

--- a/lib/rubocop/cop/rails/active_record_callbacks_order.rb
+++ b/lib/rubocop/cop/rails/active_record_callbacks_order.rb
@@ -121,13 +121,17 @@ module RuboCop
 
           processed_source.comments_before_line(annotation_line)
                           .reverse_each do |comment|
-            if comment.location.line == annotation_line
+            if comment.location.line == annotation_line && !inline_comment?(comment)
               first_comment = comment
               annotation_line -= 1
             end
           end
 
           start_line_position(first_comment || node)
+        end
+
+        def inline_comment?(comment)
+          !comment_line?(comment.loc.expression.source_line)
         end
 
         def start_line_position(node)

--- a/spec/rubocop/cop/rails/active_record_callbacks_order_spec.rb
+++ b/spec/rubocop/cop/rails/active_record_callbacks_order_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe RuboCop::Cop::Rails::ActiveRecordCallbacksOrder do
     RUBY
   end
 
-  it 'correcly autocorrects when there is a comment for callback method' do
+  it 'correcly autocorrects when there is a preceding comment for callback method' do
     new_source = autocorrect_source(<<~RUBY)
       class User < ApplicationRecord
         # This is a
@@ -61,6 +61,22 @@ RSpec.describe RuboCop::Cop::Rails::ActiveRecordCallbacksOrder do
         # multiline
         # comment for after_commit.
         after_commit :after_commit_callback
+      end
+    RUBY
+  end
+
+  it 'correcly autocorrects when there is an inline comment for callback method' do
+    new_source = autocorrect_source(<<~RUBY)
+      class User < ApplicationRecord
+        after_commit :after_commit_callback # after_commit inline comment
+        after_save :after_save_callback # after_save inline comment
+      end
+    RUBY
+
+    expect(new_source).to eq(<<~RUBY)
+      class User < ApplicationRecord
+        after_save :after_save_callback # after_save inline comment
+        after_commit :after_commit_callback # after_commit inline comment
       end
     RUBY
   end


### PR DESCRIPTION
Closes #371
