### PR TITLE
Disable `RSpec/FactoryBot/CreateList` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -93,6 +93,10 @@ Metrics/ModuleLength:
   Exclude:
     - 'spec/**/*.rb'
 
+# This disabling is a workaround for https://github.com/rubocop-hq/rubocop-rails/issues/374.
+RSpec/FactoryBot/CreateList:
+  Enabled: false
+
 RSpec/PredicateMatcher:
   EnforcedStyle: explicit
 


### PR DESCRIPTION
This PR disables `RSpec/FactoryBot/CreateList` as a workaround for https://github.com/rubocop-hq/rubocop-rails/issues/374.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
