### PR TITLE
Ask for gem version in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug Report
+about: Report an issue with RuboCop Rails you've discovered.
+---
+
+*Be clear, concise and precise in your description of the problem.
+Open an issue with a descriptive title and a summary in grammatically correct,
+complete sentences.*
+
+*Use the template below when reporting bugs. Please, make sure that
+you're running the latest stable rubocop and rubocop-rails and that the problem
+you're reporting hasn't been reported (and potentially fixed) already.*
+
+*Before filing the ticket you should replace all text above the horizontal
+rule with your own words.*
+
+--------
+
+## Expected behavior
+
+Describe here how you expected RuboCop Rails to behave in this particular situation.
+
+## Actual behavior
+
+Describe here what actually happened.
+
+## Steps to reproduce the problem
+
+This is extremely important! Providing us with a reliable way to reproduce
+a problem will expedite its solution.
+
+## Gem versions
+
+Include the version of the `rubocop-rails` gem, and the output of `rubocop -V`, or
+`bundle exec rubocop -V` if using Bundler. Here's an example:
+
+```
+$ [bundle exec] rubocop -V
+0.66.0 (using Parser 2.6.2.0, running on ruby 2.6.2 x86_64-linux)
+```


### PR DESCRIPTION
Currently we ask for the rubocop version but not the rubocop-rails version.