### PR TITLE
[Fix #384] Mark unsafe for `Rails/NegateInclude`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * [#371](https://github.com/rubocop-hq/rubocop-rails/pull/371): Fix an infinite loop error for `Rails/ActiveRecordCallbacksOrder` when callbacks have inline comments. ([@fatkodima][])
 * [#364](https://github.com/rubocop-hq/rubocop-rails/pull/364): Fix a problem that `Rails/UniqueValidationWithoutIndex` doesn't work in classes defined with compact style. ([@sinsoku][])
+* [#384](https://github.com/rubocop-hq/rubocop-rails/issues/384): Mark unsafe for `Rails/NegateInclude`. ([@koic][])
 
 ### Changes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -400,7 +400,9 @@ Rails/NegateInclude:
   Description: 'Prefer `collection.exclude?(obj)` over `!collection.include?(obj)`.'
   StyleGuide: 'https://rails.rubystyle.guide#exclude'
   Enabled: 'pending'
+  Safe: false
   VersionAdded: '2.7'
+  VersionChanged: '2.9'
 
 Rails/NotNullColumn:
   Description: 'Do not add a NOT NULL column without a default value.'

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -2314,14 +2314,17 @@ match 'photos/:id', to: 'photos#show', via: :all
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
 | Pending
-| Yes
-| Yes
+| No
+| Yes (Unsafe)
 | 2.7
-| -
+| 2.9
 |===
 
 This cop enforces the use of `collection.exclude?(obj)`
 over `!collection.include?(obj)`.
+
+It is marked as unsafe by default because false positive will occur for
+a receiver object that do not have `exclude?` method. (e.g. `IPAddr`)
 
 === Examples
 

--- a/lib/rubocop/cop/rails/negate_include.rb
+++ b/lib/rubocop/cop/rails/negate_include.rb
@@ -6,6 +6,9 @@ module RuboCop
       # This cop enforces the use of `collection.exclude?(obj)`
       # over `!collection.include?(obj)`.
       #
+      # It is marked as unsafe by default because false positive will occur for
+      # a receiver object that do not have `exclude?` method. (e.g. `IPAddr`)
+      #
       # @example
       #   # bad
       #   !array.include?(2)


### PR DESCRIPTION
Fixes #384

This PR marks unsafe for `Rails/NegateInclude` because false positive will occur for a receiver object that do not have `exclude?` method. (e.g. `IPAddr`)

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
