### PR TITLE
Use new `expect_offense`, `expect_correction` instead of old APIs

### DIFF
--- a/spec/rubocop/cop/rails/action_filter_spec.rb
+++ b/spec/rubocop/cop/rails/action_filter_spec.rb
@@ -52,20 +52,19 @@ RSpec.describe RuboCop::Cop::Rails::ActionFilter, :config do
 
     described_class::FILTER_METHODS.each do |method|
       it "registers an offense for #{method}" do
-        inspect_source_file("#{method} :name")
-        expect(cop.offenses.size).to eq(1)
+        offenses = inspect_source("#{method} :name")
+        expect(offenses.size).to eq(1)
       end
 
       it "registers an offense for #{method} with block" do
-        inspect_source_file("#{method} { |controller| something }")
-        expect(cop.offenses.size).to eq(1)
+        offenses = inspect_source("#{method} { |controller| something }")
+        expect(offenses.size).to eq(1)
       end
     end
 
     described_class::ACTION_METHODS.each do |method|
       it "accepts #{method}" do
-        inspect_source_file("#{method} :something")
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses("#{method} :something")
       end
     end
 
@@ -82,20 +81,19 @@ RSpec.describe RuboCop::Cop::Rails::ActionFilter, :config do
 
     described_class::ACTION_METHODS.each do |method|
       it "registers an offense for #{method}" do
-        inspect_source_file("#{method} :name")
-        expect(cop.offenses.size).to eq(1)
+        offenses = inspect_source("#{method} :name")
+        expect(offenses.size).to eq(1)
       end
 
       it "registers an offense for #{method} with block" do
-        inspect_source_file("#{method} { |controller| something }")
-        expect(cop.offenses.size).to eq(1)
+        offenses = inspect_source("#{method} { |controller| something }")
+        expect(offenses.size).to eq(1)
       end
     end
 
     described_class::FILTER_METHODS.each do |method|
       it "accepts #{method}" do
-        inspect_source_file("#{method} :something")
-        expect(cop.offenses.empty?).to be(true)
+        expect_no_offenses("#{method} :something")
       end
     end
 

--- a/spec/rubocop/cop/rails/blank_spec.rb
+++ b/spec/rubocop/cop/rails/blank_spec.rb
@@ -4,17 +4,15 @@ RSpec.describe RuboCop::Cop::Rails::Blank, :config do
   subject(:cop) { described_class.new(config) }
 
   shared_examples 'offense' do |source, correction, message|
-    it 'registers an offense' do
-      inspect_source(source)
+    it 'registers an offense and corrects' do
+      expect_offense(<<~RUBY, source: source, message: message)
+        #{source}
+        ^{source} #{message}
+      RUBY
 
-      expect(cop.messages).to eq([message])
-      expect(cop.highlights).to eq([source])
-    end
-
-    it 'auto-corrects' do
-      new_source = autocorrect_source(source)
-
-      expect(new_source).to eq(correction)
+      expect_correction(<<~RUBY)
+        #{correction}
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/rails/date_spec.rb
+++ b/spec/rubocop/cop/rails/date_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe RuboCop::Cop::Rails::Date, :config do
 
     shared_examples 'offense' do |method, message|
       it "registers an offense for #{method}" do
-        inspect_source(method)
-        expect(cop.messages).to eq([message])
+        offenses = inspect_source(method)
+        expect(offenses.first.message).to eq(message)
       end
     end
 
@@ -51,14 +51,14 @@ RSpec.describe RuboCop::Cop::Rails::Date, :config do
 
     %w[to_time to_time_in_current_zone].each do |method|
       it "registers an offense for ##{method}" do
-        inspect_source("date.#{method}")
-        expect(cop.offenses.size).to eq(1)
+        offenses = inspect_source("date.#{method}")
+        expect(offenses.size).to eq(1)
       end
 
       context 'when using safe navigation operator' do
         it "registers an offense for ##{method}" do
-          inspect_source("date&.#{method}")
-          expect(cop.offenses.size).to eq(1)
+          offenses = inspect_source("date&.#{method}")
+          expect(offenses.size).to eq(1)
         end
       end
 
@@ -104,8 +104,8 @@ RSpec.describe RuboCop::Cop::Rails::Date, :config do
 
     RuboCop::Cop::Rails::TimeZone::ACCEPTED_METHODS.each do |a_method|
       it "registers an offense for val.to_time.#{a_method}" do
-        inspect_source("val.to_time.#{a_method}")
-        expect(cop.offenses.size).to eq(1)
+        offenses = inspect_source("val.to_time.#{a_method}")
+        expect(offenses.size).to eq(1)
       end
     end
 

--- a/spec/rubocop/cop/rails/dynamic_find_by_spec.rb
+++ b/spec/rubocop/cop/rails/dynamic_find_by_spec.rb
@@ -7,126 +7,125 @@ RSpec.describe RuboCop::Cop::Rails::DynamicFindBy, :config do
     { 'AllowedMethods' => %w[find_by_sql] }
   end
 
-  shared_examples 'register an offense and auto correct' do |message, corrected|
-    it 'registers an offense' do
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq([message])
-    end
-
-    it 'auto-corrects' do
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq(corrected)
-    end
-  end
-
   context 'with dynamic find_by_*' do
-    let(:source) { 'User.find_by_name(name)' }
+    it 'registers an offense and corrects' do
+      expect_offense(<<~RUBY)
+        User.find_by_name(name)
+        ^^^^^^^^^^^^^^^^^^^^^^^ Use `find_by` instead of dynamic `find_by_name`.
+      RUBY
 
-    include_examples(
-      'register an offense and auto correct',
-      'Use `find_by` instead of dynamic `find_by_name`.',
-      'User.find_by(name: name)'
-    )
+      expect_correction(<<~RUBY)
+        User.find_by(name: name)
+      RUBY
+    end
   end
 
   context 'with dynamic find_by_*_and_*' do
-    let(:source) { 'User.find_by_name_and_email(name, email)' }
+    it 'registers an offense and corrects' do
+      expect_offense(<<~RUBY)
+        User.find_by_name_and_email(name, email)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `find_by` instead of dynamic `find_by_name_and_email`.
+      RUBY
 
-    include_examples(
-      'register an offense and auto correct',
-      'Use `find_by` instead of dynamic `find_by_name_and_email`.',
-      'User.find_by(name: name, email: email)'
-    )
+      expect_correction(<<~RUBY)
+        User.find_by(name: name, email: email)
+      RUBY
+    end
   end
 
   context 'with dynamic find_by_*!' do
-    let(:source) { 'User.find_by_name!(name)' }
+    it 'registers an offense and corrects' do
+      expect_offense(<<~RUBY)
+        User.find_by_name!(name)
+        ^^^^^^^^^^^^^^^^^^^^^^^^ Use `find_by!` instead of dynamic `find_by_name!`.
+      RUBY
 
-    include_examples(
-      'register an offense and auto correct',
-      'Use `find_by!` instead of dynamic `find_by_name!`.',
-      'User.find_by!(name: name)'
-    )
+      expect_correction(<<~RUBY)
+        User.find_by!(name: name)
+      RUBY
+    end
   end
 
   context 'with dynamic find_by_*_and_*_and_*' do
-    let(:source) { 'User.find_by_name_and_email_and_token(name, email, token)' }
+    it 'registers an offense and corrects' do
+      expect_offense(<<~RUBY)
+        User.find_by_name_and_email_and_token(name, email, token)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `find_by` instead of dynamic `find_by_name_and_email_and_token`.
+      RUBY
 
-    include_examples(
-      'register an offense and auto correct',
-      'Use `find_by` instead of dynamic `find_by_name_and_email_and_token`.',
-      'User.find_by(name: name, email: email, token: token)'
-    )
+      expect_correction(<<~RUBY)
+        User.find_by(name: name, email: email, token: token)
+      RUBY
+    end
   end
 
   context 'with dynamic find_by_*_and_*_and_*!' do
-    let(:source) do
-      'User.find_by_name_and_email_and_token!(name, email, token)'
-    end
+    it 'registers an offense and corrects' do
+      expect_offense(<<~RUBY)
+        User.find_by_name_and_email_and_token!(name, email, token)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `find_by!` instead of dynamic `find_by_name_and_email_and_token!`.
+      RUBY
 
-    include_examples(
-      'register an offense and auto correct',
-      'Use `find_by!` instead of dynamic `find_by_name_and_email_and_token!`.',
-      'User.find_by!(name: name, email: email, token: token)'
-    )
+      expect_correction(<<~RUBY)
+        User.find_by!(name: name, email: email, token: token)
+      RUBY
+    end
   end
 
   context 'with dynamic find_by_*_and_*_and_* with newline' do
-    let(:source) do
-      <<~RUBY
+    it 'registers an offense and corrects' do
+      expect_offense(<<~RUBY)
         User.find_by_name_and_email_and_token(
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `find_by` instead of dynamic `find_by_name_and_email_and_token`.
           name,
           email,
           token
         )
       RUBY
-    end
 
-    include_examples(
-      'register an offense and auto correct',
-      'Use `find_by` instead of dynamic `find_by_name_and_email_and_token`.',
-      <<~RUBY
+      expect_correction(<<~RUBY)
         User.find_by(
           name: name,
           email: email,
           token: token
         )
       RUBY
-    )
+    end
   end
 
   context 'with column includes undersoce' do
-    let(:source) { 'User.find_by_first_name(name)' }
+    it 'registers an offense and corrects' do
+      expect_offense(<<~RUBY)
+        User.find_by_first_name(name)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `find_by` instead of dynamic `find_by_first_name`.
+      RUBY
 
-    include_examples(
-      'register an offense and auto correct',
-      'Use `find_by` instead of dynamic `find_by_first_name`.',
-      'User.find_by(first_name: name)'
-    )
+      expect_correction(<<~RUBY)
+        User.find_by(first_name: name)
+      RUBY
+    end
   end
 
   context 'with too much arguments' do
-    let(:source) { 'User.find_by_name_and_email(name, email, token)' }
+    it 'registers an offense and no corrects' do
+      expect_offense(<<~RUBY)
+        User.find_by_name_and_email(name, email, token)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `find_by` instead of dynamic `find_by_name_and_email`.
+      RUBY
 
-    include_examples(
-      'register an offense and auto correct',
-      'Use `find_by` instead of dynamic `find_by_name_and_email`.',
-      # Do not correct
-      'User.find_by_name_and_email(name, email, token)'
-    )
+      expect_no_corrections
+    end
   end
 
   context 'with too few arguments' do
-    let(:source) { 'User.find_by_name_and_email(name)' }
+    it 'registers an offense and no corrects' do
+      expect_offense(<<~RUBY)
+        User.find_by_name_and_email(name)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `find_by` instead of dynamic `find_by_name_and_email`.
+      RUBY
 
-    include_examples(
-      'register an offense and auto correct',
-      'Use `find_by` instead of dynamic `find_by_name_and_email`.',
-      # Do not correct
-      'User.find_by_name_and_email(name)'
-    )
+      expect_no_corrections
+    end
   end
 
   it 'accepts' do
@@ -175,13 +174,16 @@ RSpec.describe RuboCop::Cop::Rails::DynamicFindBy, :config do
 
   context 'when using safe navigation operator' do
     context 'with dynamic find_by_*' do
-      let(:source) { 'user&.find_by_name(name)' }
+      it 'registers an offense and corrects' do
+        expect_offense(<<~RUBY)
+          user&.find_by_name(name)
+          ^^^^^^^^^^^^^^^^^^^^^^^^ Use `find_by` instead of dynamic `find_by_name`.
+        RUBY
 
-      include_examples(
-        'register an offense and auto correct',
-        'Use `find_by` instead of dynamic `find_by_name`.',
-        'user&.find_by(name: name)'
-      )
+        expect_correction(<<~RUBY)
+          user&.find_by(name: name)
+        RUBY
+      end
     end
   end
 

--- a/spec/rubocop/cop/rails/find_each_spec.rb
+++ b/spec/rubocop/cop/rails/find_each_spec.rb
@@ -5,9 +5,10 @@ RSpec.describe RuboCop::Cop::Rails::FindEach do
 
   shared_examples 'register_offense' do |scope|
     it "registers an offense when using #{scope}.each" do
-      inspect_source("User.#{scope}.each { |u| u.something }")
-
-      expect(cop.messages).to eq(['Use `find_each` instead of `each`.'])
+      expect_offense(<<~RUBY, scope: scope)
+        User.#{scope}.each { |u| u.something }
+             _{scope} ^^^^ Use `find_each` instead of `each`.
+      RUBY
     end
 
     it "does not register an offense when using #{scope}.order(...).each" do

--- a/spec/rubocop/cop/rails/output_spec.rb
+++ b/spec/rubocop/cop/rails/output_spec.rb
@@ -3,18 +3,23 @@
 RSpec.describe RuboCop::Cop::Rails::Output do
   subject(:cop) { described_class.new }
 
-  it 'records an offense for methods without a receiver' do
-    source = <<~RUBY
+  it 'registers an offense for methods without a receiver' do
+    expect_offense(<<~RUBY)
       p "edmond dantes"
+      ^ Do not write to stdout. Use Rails's logger if you want to log.
       puts "sinbad"
+      ^^^^ Do not write to stdout. Use Rails's logger if you want to log.
       print "abbe busoni"
+      ^^^^^ Do not write to stdout. Use Rails's logger if you want to log.
       pp "monte cristo"
+      ^^ Do not write to stdout. Use Rails's logger if you want to log.
       $stdout.write "lord wilmore"
+              ^^^^^ Do not write to stdout. Use Rails's logger if you want to log.
       $stderr.syswrite "faria"
+              ^^^^^^^^ Do not write to stdout. Use Rails's logger if you want to log.
       STDOUT.write "bertuccio"
+             ^^^^^ Do not write to stdout. Use Rails's logger if you want to log.
     RUBY
-    inspect_source(source)
-    expect(cop.offenses.size).to eq(7)
   end
 
   it 'does not record an offense for methods with a receiver' do

--- a/spec/rubocop/cop/rails/presence_spec.rb
+++ b/spec/rubocop/cop/rails/presence_spec.rb
@@ -7,16 +7,16 @@ RSpec.describe RuboCop::Cop::Rails::Presence do
 
   shared_examples 'offense' do |source, correction, first_line, end_line|
     it 'registers an offense' do
-      inspect_source(source)
+      offenses = inspect_source(source)
 
-      expect(cop.offenses.count).to eq 1
-      expect(cop.offenses).to all(
+      expect(offenses.count).to eq 1
+      expect(offenses).to all(
         have_attributes(
           first_line: first_line,
           last_line: end_line
         )
       )
-      expect(cop.offenses).to all(
+      expect(offenses).to all(
         have_attributes(
           message: "Use `#{correction}` instead of `#{source}`."
         )

--- a/spec/rubocop/cop/rails/present_spec.rb
+++ b/spec/rubocop/cop/rails/present_spec.rb
@@ -4,17 +4,15 @@ RSpec.describe RuboCop::Cop::Rails::Present, :config do
   subject(:cop) { described_class.new(config) }
 
   shared_examples 'offense' do |source, correction, message|
-    it 'registers an offense' do
-      inspect_source(source)
+    it 'registers an offense and corrects' do
+      expect_offense(<<~RUBY, source: source, message: message)
+        #{source}
+        ^{source} #{message}
+      RUBY
 
-      expect(cop.messages).to eq([message])
-      expect(cop.highlights).to eq([source])
-    end
-
-    it 'auto-corrects' do
-      new_source = autocorrect_source(source)
-
-      expect(new_source).to eq(correction)
+      expect_correction(<<~RUBY)
+        #{correction}
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/rails/reversible_migration_spec.rb
+++ b/spec/rubocop/cop/rails/reversible_migration_spec.rb
@@ -25,9 +25,9 @@ RSpec.describe RuboCop::Cop::Rails::ReversibleMigration, :config do
     let(:code) { code }
 
     it "registers an offense for #{name}" do
-      inspect_source(source)
+      offenses = inspect_source(source)
 
-      expect(cop.messages).to eq(["#{name} is not reversible."])
+      expect(offenses.first.message).to eq("#{name} is not reversible.")
     end
   end
 

--- a/spec/rubocop/cop/rails/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/rails/safe_navigation_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe RuboCop::Cop::Rails::SafeNavigation, :config do
 
   shared_examples 'offense' do |name, method, params|
     it "registers an offense for #{name}" do
-      inspect_source("[1, 2].#{method}#{params}")
+      offenses = inspect_source("[1, 2].#{method}#{params}")
 
-      expect(cop.messages)
-        .to eq([format('Use safe navigation (`&.`) instead of `%s`.', method)])
+      expect(offenses.first.message)
+        .to eq(format('Use safe navigation (`&.`) instead of `%s`.', method))
     end
   end
 

--- a/spec/rubocop/cop/rails/skips_model_validations_spec.rb
+++ b/spec/rubocop/cop/rails/skips_model_validations_spec.rb
@@ -32,10 +32,10 @@ RSpec.describe RuboCop::Cop::Rails::SkipsModelValidations, :config do
   context 'with default forbidden methods' do
     cop_config['ForbiddenMethods'].each do |method_name|
       it "registers an offense for `#{method_name}`" do
-        inspect_source("User.#{method_name}(:attr)")
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.messages)
-          .to eq([format(msg, method_name)])
+        expect_offense(<<~RUBY, method_name: method_name)
+          User.#{method_name}(:attr)
+               ^{method_name} #{format(msg, method_name)}
+        RUBY
       end
     end
 
@@ -110,10 +110,10 @@ RSpec.describe RuboCop::Cop::Rails::SkipsModelValidations, :config do
   context "with methods that don't require an argument" do
     (cop_config['ForbiddenMethods'] - methods_with_arguments).each do |method_name|
       it "registers an offense for `#{method_name}`" do
-        inspect_source("User.#{method_name}")
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.messages)
-          .to eq([format(msg, method_name)])
+        expect_offense(<<~RUBY, method_name: method_name)
+          User.#{method_name}
+               ^{method_name} #{format(msg, method_name)}
+        RUBY
       end
     end
   end

--- a/spec/rubocop/cop/rails/uniq_before_pluck_spec.rb
+++ b/spec/rubocop/cop/rails/uniq_before_pluck_spec.rb
@@ -7,9 +7,8 @@ RSpec.describe RuboCop::Cop::Rails::UniqBeforePluck, :config do
     do |method, source, action, corrected = nil|
       if action == :correct
         it "finds the use of #{method} after pluck in #{source}" do
-          inspect_source(source)
-          expect(cop.messages).to eq(['Use `distinct` before `pluck`.'])
-          expect(cop.highlights).to eq([method])
+          offenses = inspect_source(source)
+          expect(offenses.first.message).to eq('Use `distinct` before `pluck`.')
           corrected_source = corrected || 'Model.distinct.pluck(:id)'
           expect(autocorrect_source(source)).to eq(corrected_source)
         end
@@ -62,6 +61,13 @@ RSpec.describe RuboCop::Cop::Rails::UniqBeforePluck, :config do
     it_behaves_like 'UniqBeforePluck cop', method,
                     "instance.assoc.pluck(:id).#{method}", action,
                     'instance.assoc.distinct.pluck(:id)'
+  end
+
+  it 'registers an offense' do
+    expect_offense(<<~RUBY)
+      Model.pluck(:id).uniq
+                       ^^^^ Use `distinct` before `pluck`.
+    RUBY
   end
 
   %w[uniq distinct].each do |method|

--- a/spec/rubocop/cop/rails/validation_spec.rb
+++ b/spec/rubocop/cop/rails/validation_spec.rb
@@ -9,14 +9,8 @@ RSpec.describe RuboCop::Cop::Rails::Validation do
 
   described_class::RESTRICT_ON_SEND.each_with_index do |validation, number|
     it "registers an offense for #{validation}" do
-      inspect_source("#{validation} :name")
-      expect(cop.offenses.size).to eq(1)
-    end
-
-    it "outputs the correct message for #{validation}" do
-      inspect_source("#{validation} :name")
-      expect(cop.offenses.first.message)
-        .to include(described_class::ALLOWLIST[number])
+      offenses = inspect_source("#{validation} :name")
+      expect(offenses.first.message).to include(described_class::ALLOWLIST[number])
     end
   end
 


### PR DESCRIPTION
This PR uses new `expect_offense`, `expect_correction` instead of `cop.offenses`, `cop.highlights`, and `cop.messages` APIs.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
