### PR TITLE
Import `EnforceSuperclass` module

### DIFF
--- a/lib/rubocop/cop/mixin/enforce_superclass.rb
+++ b/lib/rubocop/cop/mixin/enforce_superclass.rb
@@ -18,13 +18,21 @@ module RuboCop
 
       def on_class(node)
         class_definition(node) do
-          add_offense(node.children[1])
+          register_offense(node.children[1])
         end
       end
 
       def on_send(node)
         class_new_definition(node) do
-          add_offense(node.children.last)
+          register_offense(node.children.last)
+        end
+      end
+
+      private
+
+      def register_offense(offense_node)
+        add_offense(offense_node) do |corrector|
+          corrector.replace(offense_node.source_range, self.class::SUPERCLASS)
         end
       end
     end

--- a/lib/rubocop/cop/mixin/enforce_superclass.rb
+++ b/lib/rubocop/cop/mixin/enforce_superclass.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    # Common functionality for enforcing a specific superclass.
+    module EnforceSuperclass
+      def self.included(base)
+        base.def_node_matcher :class_definition, <<~PATTERN
+          (class (const _ !:#{base::SUPERCLASS}) #{base::BASE_PATTERN} ...)
+        PATTERN
+
+        base.def_node_matcher :class_new_definition, <<~PATTERN
+          [!^(casgn {nil? cbase} :#{base::SUPERCLASS} ...)
+           !^^(casgn {nil? cbase} :#{base::SUPERCLASS} (block ...))
+           (send (const {nil? cbase} :Class) :new #{base::BASE_PATTERN})]
+        PATTERN
+      end
+
+      def on_class(node)
+        class_definition(node) do
+          add_offense(node.children[1])
+        end
+      end
+
+      def on_send(node)
+        class_new_definition(node) do
+          add_offense(node.children.last)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/rails/application_controller.rb
+++ b/lib/rubocop/cop/rails/application_controller.rb
@@ -16,7 +16,9 @@ module RuboCop
       #  class MyController < ActionController::Base
       #    # ...
       #  end
-      class ApplicationController < Cop
+      class ApplicationController < Base
+        extend AutoCorrector
+
         MSG = 'Controllers should subclass `ApplicationController`.'
         SUPERCLASS = 'ApplicationController'
         BASE_PATTERN = '(const (const nil? :ActionController) :Base)'
@@ -24,12 +26,6 @@ module RuboCop
         # rubocop:disable Layout/ClassStructure
         include RuboCop::Cop::EnforceSuperclass
         # rubocop:enable Layout/ClassStructure
-
-        def autocorrect(node)
-          lambda do |corrector|
-            corrector.replace(node.source_range, self.class::SUPERCLASS)
-          end
-        end
       end
     end
   end

--- a/lib/rubocop/cop/rails/application_job.rb
+++ b/lib/rubocop/cop/rails/application_job.rb
@@ -16,7 +16,8 @@ module RuboCop
       #  class Rails4Job < ActiveJob::Base
       #    # ...
       #  end
-      class ApplicationJob < Cop
+      class ApplicationJob < Base
+        extend AutoCorrector
         extend TargetRailsVersion
 
         minimum_target_rails_version 5.0

--- a/lib/rubocop/cop/rails/application_mailer.rb
+++ b/lib/rubocop/cop/rails/application_mailer.rb
@@ -16,7 +16,8 @@ module RuboCop
       #  class MyMailer < ActionMailer::Base
       #    # ...
       #  end
-      class ApplicationMailer < Cop
+      class ApplicationMailer < Base
+        extend AutoCorrector
         extend TargetRailsVersion
 
         minimum_target_rails_version 5.0
@@ -28,12 +29,6 @@ module RuboCop
         # rubocop:disable Layout/ClassStructure
         include RuboCop::Cop::EnforceSuperclass
         # rubocop:enable Layout/ClassStructure
-
-        def autocorrect(node)
-          lambda do |corrector|
-            corrector.replace(node.source_range, self.class::SUPERCLASS)
-          end
-        end
       end
     end
   end

--- a/lib/rubocop/cop/rails/application_record.rb
+++ b/lib/rubocop/cop/rails/application_record.rb
@@ -16,7 +16,8 @@ module RuboCop
       #  class Rails4Model < ActiveRecord::Base
       #    # ...
       #  end
-      class ApplicationRecord < Cop
+      class ApplicationRecord < Base
+        extend AutoCorrector
         extend TargetRailsVersion
 
         minimum_target_rails_version 5.0
@@ -28,12 +29,6 @@ module RuboCop
         # rubocop:disable Layout/ClassStructure
         include RuboCop::Cop::EnforceSuperclass
         # rubocop:enable Layout/ClassStructure
-
-        def autocorrect(node)
-          lambda do |corrector|
-            corrector.replace(node.source_range, self.class::SUPERCLASS)
-          end
-        end
       end
     end
   end

--- a/lib/rubocop/cop/rails_cops.rb
+++ b/lib/rubocop/cop/rails_cops.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'mixin/active_record_helper'
+require_relative 'mixin/enforce_superclass'
 require_relative 'mixin/index_method'
 require_relative 'mixin/target_rails_version'
 


### PR DESCRIPTION
Follow rubocop-hq/rubocop#7868.

This PR imports enforce superclass module  and uses `Cop::Base` API for cops mixing `EnforceSuperclass` module.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
