### PR TITLE
[Fix 376] Fix redunctantAllowNil false positive offense

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#371](https://github.com/rubocop-hq/rubocop-rails/pull/371): Fix an infinite loop error for `Rails/ActiveRecordCallbacksOrder` when callbacks have inline comments. ([@fatkodima][])
 * [#364](https://github.com/rubocop-hq/rubocop-rails/pull/364): Fix a problem that `Rails/UniqueValidationWithoutIndex` doesn't work in classes defined with compact style. ([@sinsoku][])
 * [#384](https://github.com/rubocop-hq/rubocop-rails/issues/384): Mark unsafe for `Rails/NegateInclude`. ([@koic][])
+* [#394](https://github.com/rubocop-hq/rubocop-rails/pull/394): Fix false offense detection of `Rails/RedundantAllowNil` when using both allow_nil and allow_blank on different helpers of the same validator`. ([@ngouy][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/redundant_allow_nil.rb
+++ b/lib/rubocop/cop/rails/redundant_allow_nil.rb
@@ -70,21 +70,22 @@ module RuboCop
         end
 
         def find_allow_nil_and_allow_blank(node)
-          allow_nil = nil
-          allow_blank = nil
+          allow_nil, allow_blank = nil
 
-          node.each_descendant do |descendant|
-            next unless descendant.pair_type?
+          node.each_child_node do |child_node|
+            if child_node.pair_type?
+              key = child_node.children.first.source
 
-            key = descendant.children.first.source
+              allow_nil = child_node if key == 'allow_nil'
+              allow_blank = child_node if key == 'allow_blank'
+            end
+            return [allow_nil, allow_blank] if allow_nil && allow_blank
 
-            allow_nil = descendant if key == 'allow_nil'
-            allow_blank = descendant if key == 'allow_blank'
-
-            break if allow_nil && allow_blank
+            found_in_children_nodes = find_allow_nil_and_allow_blank(child_node)
+            return found_in_children_nodes if found_in_children_nodes
           end
 
-          [allow_nil, allow_blank]
+          nil
         end
 
         def previous_sibling(node)

--- a/spec/rubocop/cop/rails/redundant_allow_nil_spec.rb
+++ b/spec/rubocop/cop/rails/redundant_allow_nil_spec.rb
@@ -81,4 +81,25 @@ RSpec.describe RuboCop::Cop::Rails::RedundantAllowNil do
       RUBY
     end
   end
+
+  context 'when using allow_nil and allow_blank on different helpers' do
+    it 'registers no offense' do
+      expect_no_offenses(<<~RUBY)
+        validates :email, format: { with: /regexp/, allow_blank: true }, presence: { allow_nil: true }
+      RUBY
+    end
+  end
+
+  context 'when using allow_nil and allow_blank true on the same helper' do
+    it 'registers no offense' do
+      expect_offense(<<~RUBY)
+        validates :email, format: { with: /regexp/, allow_nil: true, allow_blank: true }
+                                                    ^^^^^^^^^^^^^^^ `allow_nil` is redundant when `allow_blank` has the same value.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        validates :email, format: { with: /regexp/, allow_blank: true }
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fix [367](https://github.com/rubocop-hq/rubocop-rails/issues/376)

The issue occurs because we are checking the presence of allow_nil and allow_blank within the whole node tree
What we need to do is to check only the presence of this both when they are used on the same helper / level

If you want a specific message depending on the helper, it makes sense to have one or the other in different helpers of the same validation (CF issue)

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
