### PR TITLE
[Fix #401] Fix an error for `Rails/WhereEquals`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#408](https://github.com/rubocop-hq/rubocop-rails/pull/408): Fix bug in `Rails/FindEach` where config was ignored. ([@ghiculescu][])
+* [#401](https://github.com/rubocop-hq/rubocop-rails/issues/401): Fix an error for `Rails/WhereEquals` using only named placeholder template without replacement argument. ([@koic][])
 
 ## 2.9.0 (2020-12-09)
 

--- a/lib/rubocop/cop/rails/where_equals.rb
+++ b/lib/rubocop/cop/rails/where_equals.rb
@@ -68,7 +68,7 @@ module RuboCop
             when EQ_ANONYMOUS_RE, IN_ANONYMOUS_RE
               value_node.source
             when EQ_NAMED_RE, IN_NAMED_RE
-              return unless value_node.hash_type?
+              return unless value_node&.hash_type?
 
               pair = value_node.pairs.find { |p| p.key.value.to_sym == Regexp.last_match(2).to_sym }
               pair.value.source

--- a/spec/rubocop/cop/rails/where_equals_spec.rb
+++ b/spec/rubocop/cop/rails/where_equals_spec.rb
@@ -160,4 +160,12 @@ RSpec.describe RuboCop::Cop::Rails::WhereEquals do
       User.where('name = ? AND age = ?', 'john', 19)
     RUBY
   end
+
+  it 'does not register an offense when using only named placeholder template without replacement argument' do
+    expect_no_offenses(<<~'RUBY')
+      sql = User.where('name = :name').select(:id).to_sql
+
+      User.where("id IN (#{sql})", name: 'Lastname').first
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #401.

This PR fixes an error for `Rails/WhereEquals` when using only named placeholder template without replacement argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
