### PR TITLE
Rails/WhereEquals add table/column split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changes
 
 * [#404](https://github.com/rubocop-hq/rubocop-rails/issues/404): Make `Rails/HelperInstanceVariable` accepts of instance variables when a class which inherits `ActionView::Helpers::FormBuilder`. ([@koic][])
+* [#406](https://github.com/rubocop-hq/rubocop-rails/pull/406): Deconstruct "table.column" in `Rails/WhereEquals`. ([@mobilutz][])
 
 ## 2.9.0 (2020-12-09)
 

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -4448,11 +4448,13 @@ User.where('name = :name', name: 'Gabe')
 User.where('name IS NULL')
 User.where('name IN (?)', ['john', 'jane'])
 User.where('name IN (:names)', names: ['john', 'jane'])
+User.where('users.name = :name', name: 'Gabe')
 
 # good
 User.where(name: 'Gabe')
 User.where(name: nil)
 User.where(name: ['john', 'jane'])
+User.where(users: { name: 'Gabe' })
 ----
 
 === References

--- a/lib/rubocop/cop/rails/where_equals.rb
+++ b/lib/rubocop/cop/rails/where_equals.rb
@@ -13,11 +13,13 @@ module RuboCop
       #   User.where('name IS NULL')
       #   User.where('name IN (?)', ['john', 'jane'])
       #   User.where('name IN (:names)', names: ['john', 'jane'])
+      #   User.where('users.name = :name', name: 'Gabe')
       #
       #   # good
       #   User.where(name: 'Gabe')
       #   User.where(name: nil)
       #   User.where(name: ['john', 'jane'])
+      #   User.where(users: { name: 'Gabe' })
       class WhereEquals < Base
         include RangeHelp
         extend AutoCorrector
@@ -83,7 +85,9 @@ module RuboCop
 
         def build_good_method(column, value)
           if column.include?('.')
-            "where('#{column}' => #{value})"
+            table, column = column.split('.')
+
+            "where(#{table}: { #{column}: #{value} })"
           else
             "where(#{column}: #{value})"
           end

--- a/spec/rubocop/cop/rails/where_equals_spec.rb
+++ b/spec/rubocop/cop/rails/where_equals_spec.rb
@@ -61,11 +61,11 @@ RSpec.describe RuboCop::Cop::Rails::WhereEquals do
   it 'registers an offense and corrects when using `=` and namespaced columns' do
     expect_offense(<<~RUBY)
       Course.where('enrollments.student_id = ?', student.id)
-             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `where('enrollments.student_id' => student.id)` instead of manually constructing SQL.
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `where(enrollments: { student_id: student.id })` instead of manually constructing SQL.
     RUBY
 
     expect_correction(<<~RUBY)
-      Course.where('enrollments.student_id' => student.id)
+      Course.where(enrollments: { student_id: student.id })
     RUBY
   end
 
@@ -128,11 +128,11 @@ RSpec.describe RuboCop::Cop::Rails::WhereEquals do
     it 'registers an offense and corrects when using `=` and namespaced columns' do
       expect_offense(<<~RUBY)
         Course.where(['enrollments.student_id = ?', student.id])
-               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `where('enrollments.student_id' => student.id)` instead of manually constructing SQL.
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `where(enrollments: { student_id: student.id })` instead of manually constructing SQL.
       RUBY
 
       expect_correction(<<~RUBY)
-        Course.where('enrollments.student_id' => student.id)
+        Course.where(enrollments: { student_id: student.id })
       RUBY
     end
   end


### PR DESCRIPTION
With this change, the cops suggestions and autocorrect splits a namespaces column reference into 
`table: { column: value }`.

Example:
```
Comment.joins(:post).where('posts.title = ?', 'Title')
```

turns into -> 
```
Comment.joins(:post).where(posts: { title: 'Title' })
```

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
