### PR TITLE
[Fix #404] Make `Rails/HelperInstanceVariable` accept of instance variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * [#408](https://github.com/rubocop-hq/rubocop-rails/pull/408): Fix bug in `Rails/FindEach` where config was ignored. ([@ghiculescu][])
 * [#401](https://github.com/rubocop-hq/rubocop-rails/issues/401): Fix an error for `Rails/WhereEquals` using only named placeholder template without replacement argument. ([@koic][])
 
+### Changes
+
+* [#404](https://github.com/rubocop-hq/rubocop-rails/issues/404): Make `Rails/HelperInstanceVariable` accepts of instance variables when a class which inherits `ActionView::Helpers::FormBuilder`. ([@koic][])
+
 ## 2.9.0 (2020-12-09)
 
 ### New features

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -1622,6 +1622,9 @@ If it seems awkward to explicitly pass in each dependent
 variable, consider moving the behaviour elsewhere, for
 example to a model, decorator or presenter.
 
+Provided that a class inherits `ActionView::Helpers::FormBuilder`,
+an offense will not be registered.
+
 === Examples
 
 [source,ruby]
@@ -1634,6 +1637,11 @@ end
 # good
 def welcome_message(user)
   "Hello #{user.name}"
+end
+
+# good
+class MyFormBuilder < ActionView::Helpers::FormBuilder
+  @template.do_something
 end
 ----
 

--- a/lib/rubocop/cop/rails/helper_instance_variable.rb
+++ b/lib/rubocop/cop/rails/helper_instance_variable.rb
@@ -13,6 +13,9 @@ module RuboCop
       # variable, consider moving the behaviour elsewhere, for
       # example to a model, decorator or presenter.
       #
+      # Provided that a class inherits `ActionView::Helpers::FormBuilder`,
+      # an offense will not be registered.
+      #
       # @example
       #   # bad
       #   def welcome_message
@@ -23,17 +26,40 @@ module RuboCop
       #   def welcome_message(user)
       #     "Hello #{user.name}"
       #   end
+      #
+      #   # good
+      #   class MyFormBuilder < ActionView::Helpers::FormBuilder
+      #     @template.do_something
+      #   end
       class HelperInstanceVariable < Base
         MSG = 'Do not use instance variables in helpers.'
 
+        def_node_matcher :form_builder_class?, <<~PATTERN
+          (const
+            (const
+               (const nil? :ActionView) :Helpers) :FormBuilder)
+        PATTERN
+
         def on_ivar(node)
+          return if inherit_form_builder?(node)
+
           add_offense(node)
         end
 
         def on_ivasgn(node)
-          return if node.parent.or_asgn_type?
+          return if node.parent.or_asgn_type? || inherit_form_builder?(node)
 
           add_offense(node.loc.name)
+        end
+
+        private
+
+        def inherit_form_builder?(node)
+          node.each_ancestor(:class) do |class_node|
+            return true if form_builder_class?(class_node.parent_class)
+          end
+
+          false
         end
       end
     end

--- a/spec/rubocop/cop/rails/helper_instance_variable_spec.rb
+++ b/spec/rubocop/cop/rails/helper_instance_variable_spec.rb
@@ -36,4 +36,28 @@ RSpec.describe RuboCop::Cop::Rails::HelperInstanceVariable do
       end
     RUBY
   end
+
+  it 'does not register an offense when a class which inherits `ActionView::Helpers::FormBuilder`' do
+    expect_no_offenses(<<~'RUBY')
+      class MyFormBuilder < ActionView::Helpers::FormBuilder
+        def do_something
+          @template
+          @template = do_something
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using a class which does not inherit `ActionView::Helpers::FormBuilder`' do
+    expect_offense(<<~'RUBY')
+      class Foo
+        def do_something
+          @template
+          ^^^^^^^^^ Do not use instance variables in helpers.
+          @template = do_something
+          ^^^^^^^^^ Do not use instance variables in helpers.
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #404.

This PR makes `Rails/HelperInstanceVariable` accept of instance variables when class inherited `ActionView::Helpers::FormBuilder`.

It may be too broad to accept all instance variables, but view helper and form builder have different uses, so let's take a look first.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
