### PR TITLE
Fix bug in `Rails/FindEach`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#408](https://github.com/rubocop-hq/rubocop-rails/pull/408): Fix bug in `Rails/FindEach` where config was ignored. ([@ghiculescu][])
+
 ## 2.9.0 (2020-12-09)
 
 ### New features

--- a/lib/rubocop/cop/rails/find_each.rb
+++ b/lib/rubocop/cop/rails/find_each.rb
@@ -30,7 +30,7 @@ module RuboCop
         def on_send(node)
           return unless node.receiver&.send_type?
           return unless SCOPE_METHODS.include?(node.receiver.method_name)
-          return if method_chain(node).any? { |m| ignored?(m) }
+          return if ignored?(node)
 
           range = node.loc.selector
           add_offense(range) do |corrector|
@@ -40,12 +40,9 @@ module RuboCop
 
         private
 
-        def method_chain(node)
-          node.each_node(:send).map(&:method_name)
-        end
-
-        def ignored?(relation_method)
-          cop_config['IgnoredMethods'].include?(relation_method)
+        def ignored?(node)
+          method_chain = node.each_node(:send).map(&:method_name)
+          (cop_config['IgnoredMethods'].map(&:to_sym) & method_chain).any?
         end
       end
     end

--- a/spec/rubocop/cop/rails/find_each_spec.rb
+++ b/spec/rubocop/cop/rails/find_each_spec.rb
@@ -74,6 +74,10 @@ RSpec.describe RuboCop::Cop::Rails::FindEach, :config do
       expect_no_offenses('User.order(:name).each { |u| u.something }')
     end
 
+    it 'does not register an offense when using order(...) chained with other things' do
+      expect_no_offenses('User.order(:name).includes(:company).each { |u| u.something }')
+    end
+
     it 'does not register an offense when using lock earlier' do
       expect_no_offenses('User.lock.each { |u| u.something }')
     end


### PR DESCRIPTION
Fixes a bug in https://github.com/rubocop-hq/rubocop-rails/pull/392

It never worked, because it was comparing strings (from config) to symbols (from [`method_name`](https://rubydoc.info/github/rubocop-hq/rubocop-ast/RuboCop%2FAST%2FDefNode:method_name)). The tests only passed because of what was in `SCOPE_METHODS`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
