### PR TITLE
`Rails/WhereNot` add table/column split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#409](https://github.com/rubocop-hq/rubocop-rails/pull/409): Deconstruct "table.column" in `Rails/WhereNot`. ([@mobilutz][])
+
 ## 2.9.1 (2020-12-16)
 
 ### Bug fixes

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -4554,11 +4554,13 @@ User.where('name <> :name', name: 'Gabe')
 User.where('name IS NOT NULL')
 User.where('name NOT IN (?)', ['john', 'jane'])
 User.where('name NOT IN (:names)', names: ['john', 'jane'])
+User.where('users.name != :name', name: 'Gabe')
 
 # good
 User.where.not(name: 'Gabe')
 User.where.not(name: nil)
 User.where.not(name: ['john', 'jane'])
+User.where.not(users: { name: 'Gabe' })
 ----
 
 === References

--- a/lib/rubocop/cop/rails/where_not.rb
+++ b/lib/rubocop/cop/rails/where_not.rb
@@ -15,11 +15,13 @@ module RuboCop
       #   User.where('name IS NOT NULL')
       #   User.where('name NOT IN (?)', ['john', 'jane'])
       #   User.where('name NOT IN (:names)', names: ['john', 'jane'])
+      #   User.where('users.name != :name', name: 'Gabe')
       #
       #   # good
       #   User.where.not(name: 'Gabe')
       #   User.where.not(name: nil)
       #   User.where.not(name: ['john', 'jane'])
+      #   User.where.not(users: { name: 'Gabe' })
       #
       class WhereNot < Base
         include RangeHelp
@@ -86,7 +88,9 @@ module RuboCop
 
         def build_good_method(column, value)
           if column.include?('.')
-            "where.not('#{column}' => #{value})"
+            table, column = column.split('.')
+
+            "where.not(#{table}: { #{column}: #{value} })"
           else
             "where.not(#{column}: #{value})"
           end

--- a/spec/rubocop/cop/rails/where_not_spec.rb
+++ b/spec/rubocop/cop/rails/where_not_spec.rb
@@ -83,22 +83,22 @@ RSpec.describe RuboCop::Cop::Rails::WhereNot do
   it 'registers an offense and corrects when using `!=` and namespaced columns' do
     expect_offense(<<~RUBY)
       Course.where('enrollments.student_id != ?', student.id)
-             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `where.not('enrollments.student_id' => student.id)` instead of manually constructing negated SQL in `where`.
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `where.not(enrollments: { student_id: student.id })` instead of manually constructing negated SQL in `where`.
     RUBY
 
     expect_correction(<<~RUBY)
-      Course.where.not('enrollments.student_id' => student.id)
+      Course.where.not(enrollments: { student_id: student.id })
     RUBY
   end
 
   it 'registers an offense and corrects when using `<>` and namespaced columns' do
     expect_offense(<<~RUBY)
       Course.where('enrollments.student_id <> ?', student.id)
-             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `where.not('enrollments.student_id' => student.id)` instead of manually constructing negated SQL in `where`.
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `where.not(enrollments: { student_id: student.id })` instead of manually constructing negated SQL in `where`.
     RUBY
 
     expect_correction(<<~RUBY)
-      Course.where.not('enrollments.student_id' => student.id)
+      Course.where.not(enrollments: { student_id: student.id })
     RUBY
   end
 
@@ -183,22 +183,22 @@ RSpec.describe RuboCop::Cop::Rails::WhereNot do
     it 'registers an offense and corrects when using `!=` and namespaced columns' do
       expect_offense(<<~RUBY)
         Course.where(['enrollments.student_id != ?', student.id])
-               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `where.not('enrollments.student_id' => student.id)` instead of manually constructing negated SQL in `where`.
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `where.not(enrollments: { student_id: student.id })` instead of manually constructing negated SQL in `where`.
       RUBY
 
       expect_correction(<<~RUBY)
-        Course.where.not('enrollments.student_id' => student.id)
+        Course.where.not(enrollments: { student_id: student.id })
       RUBY
     end
 
     it 'registers an offense and corrects when using `<>` and namespaced columns' do
       expect_offense(<<~RUBY)
         Course.where(['enrollments.student_id <> ?', student.id])
-               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `where.not('enrollments.student_id' => student.id)` instead of manually constructing negated SQL in `where`.
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `where.not(enrollments: { student_id: student.id })` instead of manually constructing negated SQL in `where`.
       RUBY
 
       expect_correction(<<~RUBY)
-        Course.where.not('enrollments.student_id' => student.id)
+        Course.where.not(enrollments: { student_id: student.id })
       RUBY
     end
   end


### PR DESCRIPTION
With this change, the cops suggestions and autocorrect splits a namespaces column reference into 
`table: { column: value }`.

Example:
```
Comment.joins(:post).where.not('posts.title = ?', 'Title')
```

turns into -> 
```
Comment.joins(:post).where.not(posts: { title: 'Title' })
```

PS: Almost the same as #406 

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
