### PR TITLE
[Fix #415] Make `Rails/HasManyOrHasOneDependent` accept association extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * [#409](https://github.com/rubocop-hq/rubocop-rails/pull/409): Deconstruct "table.column" in `Rails/WhereNot`. ([@mobilutz][])
+* [#416](https://github.com/rubocop-hq/rubocop-rails/pull/416): Make `Rails/HasManyOrHasOneDependent` accept combination of association extension and `with_options`. ([@ohbarye][])
 
 ## 2.9.1 (2020-12-16)
 
@@ -329,3 +330,4 @@
 [@Tietew]: https://github.com/Tietew
 [@cilim]: https://github.com/cilim
 [@flanger001]: https://github.com/flanger001
+[@ohbarye]: https://github.com/ohbarye

--- a/lib/rubocop/cop/rails/has_many_or_has_one_dependent.rb
+++ b/lib/rubocop/cop/rails/has_many_or_has_one_dependent.rb
@@ -51,6 +51,12 @@ module RuboCop
             (args) ...)
         PATTERN
 
+        def_node_matcher :association_extension_block?, <<~PATTERN
+          (block
+            (send nil? :has_many _)
+            (args) ...)
+        PATTERN
+
         def on_send(node)
           return if active_resource?(node.parent)
           return if !association_without_options?(node) && valid_options?(association_with_options?(node))
@@ -64,7 +70,7 @@ module RuboCop
         def valid_options_in_with_options_block?(node)
           return true unless node.parent
 
-          n = node.parent.begin_type? ? node.parent.parent : node.parent
+          n = node.parent.begin_type? || association_extension_block?(node.parent) ? node.parent.parent : node.parent
 
           contain_valid_options_in_with_options_block?(n)
         end

--- a/spec/rubocop/cop/rails/has_many_or_has_one_dependent_spec.rb
+++ b/spec/rubocop/cop/rails/has_many_or_has_one_dependent_spec.rb
@@ -132,6 +132,19 @@ RSpec.describe RuboCop::Cop::Rails::HasManyOrHasOneDependent do
         RUBY
       end
 
+      it "doesn't register an offense for `with_options dependent: :destroy` and for using association extension" do
+        expect_no_offenses(<<~RUBY)
+          class Person < ApplicationRecord
+            with_options dependent: :destroy do
+              has_many :foo do
+                def bar
+                end
+              end
+            end
+          end
+        RUBY
+      end
+
       context 'Multiple associations' do
         it "doesn't register an offense for " \
            '`with_options dependent: :destroy`' do


### PR DESCRIPTION
Fixes #415

This pull request makes `Rails/HasManyOrHasOneDependent` accept combination of association extension and `with_options`.


```ruby
class Person < ApplicationRecord
  with_options dependent: :destroy do
    has_many :foo do
      def bar
      end
    end
  end
end
```

The code above is going to be parsed as below.

```
s(:class,
  s(:const, nil, :Person),
  s(:const, nil, :ApplicationRecord),
  s(:block,
    s(:send, nil, :with_options,
      s(:hash,
        s(:pair,
          s(:sym, :dependent),
          s(:sym, :destroy)))),
    s(:args),
    s(:block,
      s(:send, nil, :has_many,
        s(:sym, :foo)),
      s(:args),
      s(:def, :bar,
        s(:args), nil))))
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
