### PR TITLE
[Fix #421] Fix incorrect auto-correct for `Rails/LinkToBlank`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#421](https://github.com/rubocop-hq/rubocop-rails/issues/421): Fix incorrect auto-correct for `Rails/LinkToBlank` when using `target: '_blank'` with hash brackets for the option. ([@koic][])
+
 ### Changes
 
 * [#409](https://github.com/rubocop-hq/rubocop-rails/pull/409): Deconstruct "table.column" in `Rails/WhereNot`. ([@mobilutz][])

--- a/lib/rubocop/cop/rails/link_to_blank.rb
+++ b/lib/rubocop/cop/rails/link_to_blank.rb
@@ -79,7 +79,11 @@ module RuboCop
           opening_quote = offence_node.children.last.source[0]
           closing_quote = opening_quote == ':' ? '' : opening_quote
           new_rel_exp = ", rel: #{opening_quote}noopener#{closing_quote}"
-          range = send_node.arguments.last.source_range
+          range = if (last_argument = send_node.last_argument).hash_type?
+                    last_argument.pairs.last.source_range
+                  else
+                    last_argument.source_range
+                  end
 
           corrector.insert_after(range, new_rel_exp)
         end

--- a/spec/rubocop/cop/rails/link_to_blank_spec.rb
+++ b/spec/rubocop/cop/rails/link_to_blank_spec.rb
@@ -92,6 +92,17 @@ RSpec.describe RuboCop::Cop::Rails::LinkToBlank do
           link_to 'Click here', 'https://www.example.com', target: :_blank, rel: :noopener
         RUBY
       end
+
+      it 'registers and corrects an offence when using hash brackets for the option' do
+        expect_offense(<<~RUBY)
+          link_to 'Click here', 'https://www.example.com', { target: :_blank }
+                                                             ^^^^^^^^^^^^^^^ Specify a `:rel` option containing noopener.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          link_to 'Click here', 'https://www.example.com', { target: :_blank, rel: :noopener }
+        RUBY
+      end
     end
 
     context 'when using rel' do


### PR DESCRIPTION
Fixes #421.

This PR fixes incorrect auto-correct for `Rails/LinkToBlank` when using `target: '_blank'` with hash brackets for the option.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
