### PR TITLE
Tweak offense highlight range for `Rails/HttpPositionalArgument`

### DIFF
--- a/lib/rubocop/cop/rails/http_positional_arguments.rb
+++ b/lib/rubocop/cop/rails/http_positional_arguments.rb
@@ -18,6 +18,7 @@ module RuboCop
       #   get :new, params: { user_id: 1 }
       #   get :new, **options
       class HttpPositionalArguments < Base
+        include RangeHelp
         extend AutoCorrector
         extend TargetRailsVersion
 
@@ -44,7 +45,7 @@ module RuboCop
 
             message = format(MSG, verb: node.method_name)
 
-            add_offense(node.loc.selector, message: message) do |corrector|
+            add_offense(highlight_range(node), message: message) do |corrector|
               # given a pre Rails 5 method: get :new, {user_id: @user.id}, {}
               #
               # @return lambda of auto correct procedure
@@ -78,6 +79,12 @@ module RuboCop
 
         def format_arg?(node)
           node.sym_type? && node.value == :format
+        end
+
+        def highlight_range(node)
+          _http_path, *data = *node.arguments
+
+          range_between(data.first.source_range.begin_pos, data.last.source_range.end_pos)
         end
 
         def convert_hash_data(data, type)

--- a/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
+++ b/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
     it 'registers an offense for get method' do
       expect_offense(<<~RUBY)
         get :create, user_id: @user.id
-        ^^^ Use keyword arguments instead of positional arguments for http call: `get`.
+                     ^^^^^^^^^^^^^^^^^ Use keyword arguments instead of positional arguments for http call: `get`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -122,7 +122,7 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
     it 'registers an offense for post method' do
       expect_offense(<<~RUBY)
         post :create, user_id: @user.id
-        ^^^^ Use keyword arguments instead of positional arguments for http call: `post`.
+                      ^^^^^^^^^^^^^^^^^ Use keyword arguments instead of positional arguments for http call: `post`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -133,7 +133,7 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
     it 'registers an offense for patch method' do
       expect_offense(<<~RUBY)
         patch :update, user_id: @user.id
-        ^^^^^ Use keyword arguments instead of positional arguments for http call: `patch`.
+                       ^^^^^^^^^^^^^^^^^ Use keyword arguments instead of positional arguments for http call: `patch`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -144,7 +144,7 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
     it 'registers an offense for put method' do
       expect_offense(<<~RUBY)
         put :create, user_id: @user.id
-        ^^^ Use keyword arguments instead of positional arguments for http call: `put`.
+                     ^^^^^^^^^^^^^^^^^ Use keyword arguments instead of positional arguments for http call: `put`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -155,7 +155,7 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
     it 'registers an offense for delete method' do
       expect_offense(<<~RUBY)
         delete :create, user_id: @user.id
-        ^^^^^^ Use keyword arguments instead of positional arguments for http call: `delete`.
+                        ^^^^^^^^^^^^^^^^^ Use keyword arguments instead of positional arguments for http call: `delete`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -166,7 +166,7 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
     it 'registers an offense for head method' do
       expect_offense(<<~RUBY)
         head :create, user_id: @user.id
-        ^^^^ Use keyword arguments instead of positional arguments for http call: `head`.
+                      ^^^^^^^^^^^^^^^^^ Use keyword arguments instead of positional arguments for http call: `head`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -209,7 +209,7 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           get :new, user_id: @user.id
-          ^^^ Use keyword arguments instead of positional arguments for http call: `get`.
+                    ^^^^^^^^^^^^^^^^^ Use keyword arguments instead of positional arguments for http call: `get`.
         RUBY
 
         expect_correction(<<~RUBY)
@@ -228,8 +228,8 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
       it 'autocorrects offense' do
         expect_offense(<<~RUBY)
           patch :update,
-          ^^^^^ Use keyword arguments instead of positional arguments for http call: `patch`.
                 id: @user.id,
+                ^^^^^^^^^^^^^ Use keyword arguments instead of positional arguments for http call: `patch`.
                 ac: {
                   article_id: @article1.id,
                   profile_id: @profile1.id,
@@ -251,8 +251,8 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
       it 'autocorrects offense' do
         expect_offense(<<~RUBY)
           post :create,
-          ^^^^ Use keyword arguments instead of positional arguments for http call: `post`.
                id: @user.id,
+               ^^^^^^^^^^^^^ Use keyword arguments instead of positional arguments for http call: `post`.
                ac: {
                  article_id: @article1.id,
                  profile_id: @profile1.id,
@@ -279,7 +279,7 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
     it 'auto-corrects http action when method' do
       expect_offense(<<~RUBY)
         post user_attrs, id: 1
-        ^^^^ Use keyword arguments instead of positional arguments for http call: `post`.
+                         ^^^^^ Use keyword arguments instead of positional arguments for http call: `post`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -290,7 +290,7 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
     it 'auto-corrects http action when symbol' do
       expect_offense(<<~RUBY)
         post :user_attrs, id: 1
-        ^^^^ Use keyword arguments instead of positional arguments for http call: `post`.
+                          ^^^^^ Use keyword arguments instead of positional arguments for http call: `post`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -301,7 +301,7 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
     it 'maintains parentheses when auto-correcting' do
       expect_offense(<<~RUBY)
         post(:user_attrs, id: 1)
-        ^^^^ Use keyword arguments instead of positional arguments for http call: `post`.
+                          ^^^^^ Use keyword arguments instead of positional arguments for http call: `post`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -312,7 +312,7 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
     it 'maintains quotes when auto-correcting' do
       expect_offense(<<~RUBY)
         get '/auth/linkedin/callback', id: 1
-        ^^^ Use keyword arguments instead of positional arguments for http call: `get`.
+                                       ^^^^^ Use keyword arguments instead of positional arguments for http call: `get`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -323,7 +323,7 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
     it 'does add session keyword when session is used' do
       expect_offense(<<~RUBY)
         get some_path(profile.id), {}, 'HTTP_REFERER' => p_url(p.id).to_s
-        ^^^ Use keyword arguments instead of positional arguments for http call: `get`.
+                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use keyword arguments instead of positional arguments for http call: `get`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -334,7 +334,7 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
     it 'does not duplicate brackets when hash is already supplied' do
       expect_offense(<<~RUBY)
         get some_path(profile.id), { user_id: @user.id, profile_id: p.id }, 'HTTP_REFERER' => p_url(p.id).to_s
-        ^^^ Use keyword arguments instead of positional arguments for http call: `get`.
+                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use keyword arguments instead of positional arguments for http call: `get`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -345,7 +345,7 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
     it 'auto-corrects http action when params is a method call' do
       expect_offense(<<~RUBY)
         post :create, confirmation_data
-        ^^^^ Use keyword arguments instead of positional arguments for http call: `post`.
+                      ^^^^^^^^^^^^^^^^^ Use keyword arguments instead of positional arguments for http call: `post`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -357,7 +357,7 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
       'special keyword name' do
       expect_offense(<<~RUBY)
         post :create, id: 7, comment: { body: "hei" }
-        ^^^^ Use keyword arguments instead of positional arguments for http call: `post`.
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use keyword arguments instead of positional arguments for http call: `post`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -368,7 +368,7 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
     it 'auto-corrects http action when format keyword included but not alone' do
       expect_offense(<<~RUBY)
         post :create, id: 7, format: :rss
-        ^^^^ Use keyword arguments instead of positional arguments for http call: `post`.
+                      ^^^^^^^^^^^^^^^^^^^ Use keyword arguments instead of positional arguments for http call: `post`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -380,7 +380,7 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
       expect_offense(<<~RUBY)
         params = { id: 1 }
         post user_attrs, params
-        ^^^^ Use keyword arguments instead of positional arguments for http call: `post`.
+                         ^^^^^^ Use keyword arguments instead of positional arguments for http call: `post`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -393,7 +393,7 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
       'are method calls' do
       expect_offense(<<~RUBY)
         post user_attrs, params
-        ^^^^ Use keyword arguments instead of positional arguments for http call: `post`.
+                         ^^^^^^ Use keyword arguments instead of positional arguments for http call: `post`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -404,7 +404,7 @@ RSpec.describe RuboCop::Cop::Rails::HttpPositionalArguments do
     it 'auto-corrects http action when params is a method call with chain' do
       expect_offense(<<~RUBY)
         post user_attrs, params.merge(foo: bar)
-        ^^^^ Use keyword arguments instead of positional arguments for http call: `post`.
+                         ^^^^^^^^^^^^^^^^^^^^^^ Use keyword arguments instead of positional arguments for http call: `post`.
       RUBY
 
       expect_correction(<<~RUBY)


### PR DESCRIPTION
This PR tweaks offense highlight range for `Rails/HttpPositionalArgument`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
