### PR TITLE
[Fix #436] Fix a false positive for `Rails/ContentTag`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#421](https://github.com/rubocop-hq/rubocop-rails/issues/421): Fix incorrect auto-correct for `Rails/LinkToBlank` when using `target: '_blank'` with hash brackets for the option. ([@koic][])
+* [#436](https://github.com/rubocop-hq/rubocop-rails/issues/436): Fix a false positive for `Rails/ContentTag` when the first argument is a splat argument. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/content_tag.rb
+++ b/lib/rubocop/cop/rails/content_tag.rb
@@ -30,9 +30,7 @@ module RuboCop
 
         def on_send(node)
           first_argument = node.first_argument
-          return unless first_argument
-
-          return if first_argument.variable? || first_argument.send_type? || first_argument.const_type?
+          return if !first_argument || allowed_argument?(first_argument)
 
           add_offense(node) do |corrector|
             autocorrect(corrector, node)
@@ -40,6 +38,10 @@ module RuboCop
         end
 
         private
+
+        def allowed_argument?(argument)
+          argument.variable? || argument.send_type? || argument.const_type? || argument.splat_type?
+        end
 
         def autocorrect(corrector, node)
           if method_name?(node.first_argument)

--- a/spec/rubocop/cop/rails/content_tag_spec.rb
+++ b/spec/rubocop/cop/rails/content_tag_spec.rb
@@ -165,6 +165,12 @@ RSpec.describe RuboCop::Cop::Rails::ContentTag, :config do
           content_tag($name, "Hello world!", class: ["strong", "highlight"])
         RUBY
       end
+
+      it 'does not register an offence when the first argument is a splat argument' do
+        expect_no_offenses(<<~RUBY)
+          content_tag(*args, &block)
+        RUBY
+      end
     end
 
     context 'when the first argument is a method' do


### PR DESCRIPTION
Fixes #436.

This PR fixes a false positive for `Rails/ContentTag` when the first argument is a splat argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
