### PR TITLE
[Fix #435] Fix a false negative for `Rails/BelongsTo`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#421](https://github.com/rubocop-hq/rubocop-rails/issues/421): Fix incorrect auto-correct for `Rails/LinkToBlank` when using `target: '_blank'` with hash brackets for the option. ([@koic][])
 * [#436](https://github.com/rubocop-hq/rubocop-rails/issues/436): Fix a false positive for `Rails/ContentTag` when the first argument is a splat argument. ([@koic][])
+* [#435](https://github.com/rubocop-hq/rubocop-rails/issues/435): Fix a false negative for `Rails/BelongsTo` when using `belongs_to` lambda block with `required` option. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/belongs_to.rb
+++ b/lib/rubocop/cop/rails/belongs_to.rb
@@ -68,7 +68,7 @@ module RuboCop
         RESTRICT_ON_SEND = %i[belongs_to].freeze
 
         def_node_matcher :match_belongs_to_with_options, <<~PATTERN
-          (send _ :belongs_to _
+          (send _ :belongs_to ...
             (hash <$(pair (sym :required) ${true false}) ...>)
           )
         PATTERN

--- a/spec/rubocop/cop/rails/belongs_to_spec.rb
+++ b/spec/rubocop/cop/rails/belongs_to_spec.rb
@@ -23,6 +23,17 @@ RSpec.describe RuboCop::Cop::Rails::BelongsTo, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when using `belongs_to` lambda block with `required: false`' do
+    expect_offense(<<~RUBY)
+      belongs_to :foo, -> { bar }, required: false
+      ^^^^^^^^^^ You specified `required: false`, in Rails > 5.0 the required option is deprecated and you want to use `optional: true`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      belongs_to :foo, -> { bar }, optional: true
+    RUBY
+  end
+
   it 'registers no offense when setting `optional: true`' do
     expect_no_offenses('belongs_to :foo, optional: true')
   end


### PR DESCRIPTION
Fixes #435.

This PR fixes a false negative for `Rails/BelongsTo` when using `belongs_to` lambda block with `required` option.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
