### PR TITLE
[Fix #432] Exclude gemspec file by default for `Rails/TimeZone` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * [#409](https://github.com/rubocop-hq/rubocop-rails/pull/409): Deconstruct "table.column" in `Rails/WhereNot`. ([@mobilutz][])
 * [#416](https://github.com/rubocop-hq/rubocop-rails/pull/416): Make `Rails/HasManyOrHasOneDependent` accept combination of association extension and `with_options`. ([@ohbarye][])
+* [#432](https://github.com/rubocop-hq/rubocop-rails/issues/432): Exclude gemspec file by default for `Rails/TimeZone` cop. ([@koic][])
 
 ## 2.9.1 (2020-12-16)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -687,13 +687,15 @@ Rails/TimeZone:
   Enabled: true
   Safe: false
   VersionAdded: '0.30'
-  VersionChanged: '0.68'
+  VersionChanged: '2.10'
   # The value `strict` means that `Time` should be used with `zone`.
   # The value `flexible` allows usage of `in_time_zone` instead of `zone`.
   EnforcedStyle: flexible
   SupportedStyles:
     - strict
     - flexible
+  Exclude:
+    - '**/*.gemspec'
 
 Rails/UniqBeforePluck:
   Description: 'Prefer the use of uniq or distinct before pluck.'

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -4133,7 +4133,7 @@ SQL
 | No
 | Yes (Unsafe)
 | 0.30
-| 0.68
+| 2.10
 |===
 
 This cop checks for the use of Time methods without zone.
@@ -4195,6 +4195,10 @@ Time.at(timestamp).in_time_zone
 | EnforcedStyle
 | `flexible`
 | `strict`, `flexible`
+
+| Exclude
+| `**/*.gemspec`
+| Array
 |===
 
 === References


### PR DESCRIPTION
Fixes #432.

This PR excludes gemspec file by default for `Rails/TimeZone` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
