### PR TITLE
[Fix #440] Make `Rails/TimeZone` aware of timezone specifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#409](https://github.com/rubocop-hq/rubocop-rails/pull/409): Deconstruct "table.column" in `Rails/WhereNot`. ([@mobilutz][])
 * [#416](https://github.com/rubocop-hq/rubocop-rails/pull/416): Make `Rails/HasManyOrHasOneDependent` accept combination of association extension and `with_options`. ([@ohbarye][])
 * [#432](https://github.com/rubocop-hq/rubocop-rails/issues/432): Exclude gemspec file by default for `Rails/TimeZone` cop. ([@koic][])
+* [#440](https://github.com/rubocop-hq/rubocop-rails/issues/440): This PR makes `Rails/TimeZone` aware of timezone specifier. ([@koic][])
 
 ## 2.9.1 (2020-12-16)
 

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -4157,7 +4157,7 @@ to use Time.in_time_zone.
 
 # bad
 Time.now
-Time.parse('2015-03-02 19:05:37')
+Time.parse('2015-03-02T19:05:37')
 
 # bad
 Time.current
@@ -4165,7 +4165,8 @@ Time.at(timestamp).in_time_zone
 
 # good
 Time.zone.now
-Time.zone.parse('2015-03-02 19:05:37')
+Time.zone.parse('2015-03-02T19:05:37')
+Time.zone.parse('2015-03-02T19:05:37Z') # Respect ISO 8601 format with timezone specifier.
 ----
 
 ==== EnforcedStyle: flexible (default)
@@ -4176,11 +4177,11 @@ Time.zone.parse('2015-03-02 19:05:37')
 
 # bad
 Time.now
-Time.parse('2015-03-02 19:05:37')
+Time.parse('2015-03-02T19:05:37')
 
 # good
 Time.zone.now
-Time.zone.parse('2015-03-02 19:05:37')
+Time.zone.parse('2015-03-02T19:05:37')
 
 # good
 Time.current

--- a/spec/rubocop/cop/rails/time_zone_spec.rb
+++ b/spec/rubocop/cop/rails/time_zone_spec.rb
@@ -126,6 +126,24 @@ RSpec.describe RuboCop::Cop::Rails::TimeZone, :config do
       RUBY
     end
 
+    it 'does not register an offense when attaching timezone specifier `Z`' do
+      expect_no_offenses(<<~RUBY)
+        Time.parse("2012-03-02T16:05:37Z")
+      RUBY
+    end
+
+    it 'does not register an offense when attaching timezone specifier `z`' do
+      expect_no_offenses(<<~RUBY)
+        Time.parse("2012-03-02T16:05:37z")
+      RUBY
+    end
+
+    it 'does not register an offense when attaching timezone specifier `E`' do
+      expect_no_offenses(<<~RUBY)
+        Time.parse("2012-03-02T16:05:37E")
+      RUBY
+    end
+
     it 'registers an offense for Time.at' do
       expect_offense(<<~RUBY)
         Time.at(ts)


### PR DESCRIPTION
Fixes #440.

This PR makes `Rails/TimeZone` aware of timezone specifier.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-rails/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-rails/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
