### PR TITLE
Fix a false-positive with Rails/RelativeDateConstant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 
+* [#482](https://github.com/rubocop/rubocop-rails/pull/482): Fix a false positive for `Rails/RelativeDateConstant` when assigning (hashes/arrays/etc)-containing procs to a constant. ([@jdelStrother][])
 * [#419](https://github.com/rubocop/rubocop-rails/issues/419): Fix an error for `Rails/UniqueValidationWithoutIndex` when using a unique index and `check_constraint` that has `nil` first argument. ([@koic][])
 
 ## 2.10.1 (2021-05-06)
@@ -382,3 +383,4 @@
 [@leonp1991]: https://github.com/leonp1991
 [@drenmi]: https://github.com/drenmi
 [@rhymes]: https://github.com/rhymes
+[@jdelStrother]: https://github.com/jdelStrother

--- a/spec/rubocop/cop/rails/relative_date_constant_spec.rb
+++ b/spec/rubocop/cop/rails/relative_date_constant_spec.rb
@@ -26,6 +26,17 @@ RSpec.describe RuboCop::Cop::Rails::RelativeDateConstant, :config do
       RUBY
     end
 
+    it 'accepts a nested proc' do
+      expect_no_offenses(<<~RUBY)
+        class SomeClass
+          EXPIRIES = {
+            yearly: Proc.new { 1.year.ago },
+            monthly: Proc.new { 1.month.ago }
+          }
+        end
+      RUBY
+    end
+
     it 'registers an offense for ActiveSupport::Duration.since' do
       expect_offense(<<~RUBY)
         class SomeClass


### PR DESCRIPTION
Prior to this, procs would only be allowed for the top-level assignment - eg

```ruby
FOO = 1.week.ago # bad
FOO = Proc.new { 1.week.ago } # good
```

but didn't accept cases where the Proc was nested further down, eg:

```ruby
FOO = {
  weekly: Proc.new { 1.week.ago } # bad (but should be good!)
}
```

This patch changes the RelativeDateConstant to recursive down through
the child nodes of the const-assignment, stopping whenever a Proc is
encountered.

As a result, ranges no longer need special-casing, so I've removed the
handling for those.

