### PR TITLE
Fix an error for `Rails/FindEach`

### DIFF
--- a/changelog/fix_an_error_for_rails_find_each.md
+++ b/changelog/fix_an_error_for_rails_find_each.md
@@ -1,0 +1,1 @@
+* [#573](https://github.com/rubocop/rubocop-rails/pull/573): Fix an error for `Rails/FindEach` when using `where` with no receiver. ([@koic][])

--- a/lib/rubocop/cop/rails/find_each.rb
+++ b/lib/rubocop/cop/rails/find_each.rb
@@ -55,6 +55,8 @@ module RuboCop
         end
 
         def active_model_error?(node)
+          return false if node.nil?
+
           node.send_type? && node.method?(:errors)
         end
       end

--- a/spec/rubocop/cop/rails/find_each_spec.rb
+++ b/spec/rubocop/cop/rails/find_each_spec.rb
@@ -45,7 +45,18 @@ RSpec.describe RuboCop::Cop::Rails::FindEach, :config do
   # Active Model Errors slice from the new query interface introduced in Rails 6.1.
   it 'does not register an offense when using `model.errors.where`' do
     expect_no_offenses(<<~RUBY)
-      model.errors.where(:title).each { |error| do_something(error)  }
+      class Model < ApplicationRecord
+        model.errors.where(:title).each { |error| do_something(error)  }
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using `where` with no receiver' do
+    expect_offense(<<~RUBY)
+      class Model < ApplicationRecord
+        where(record: [record1, record2]).each(&:touch)
+                                          ^^^^ Use `find_each` instead of `each`.
+      end
     RUBY
   end
 


### PR DESCRIPTION
Follow up to https://github.com/rubocop/rubocop-rails/pull/552#issuecomment-936231105.

This PR fixes an error for `Rails/FindEach` when using `where` with no receiver.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
