### PR TITLE
Mark `Rails/TimeZone` as unsafe auto-correction from unsafe

### DIFF
--- a/changelog/change_mark_rails_time_zone_as_unsafe_auto_correction.md
+++ b/changelog/change_mark_rails_time_zone_as_unsafe_auto_correction.md
@@ -1,0 +1,1 @@
+* [#576](https://github.com/rubocop/rubocop-rails/pull/576): Mark `Rails/TimeZone` as unsafe auto-correction from unsafe. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -789,9 +789,9 @@ Rails/TimeZone:
   StyleGuide: 'https://rails.rubystyle.guide#time'
   Reference: 'http://danilenko.org/2012/7/6/rails_timezones'
   Enabled: true
-  Safe: false
+  SafeAutoCorrect: false
   VersionAdded: '0.30'
-  VersionChanged: '2.10'
+  VersionChanged: '2.13'
   # The value `strict` means that `Time` should be used with `zone`.
   # The value `flexible` allows usage of `in_time_zone` instead of `zone`.
   EnforcedStyle: flexible

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -4600,10 +4600,10 @@ SQL
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
 | Enabled
-| No
+| Yes
 | Yes (Unsafe)
 | 0.30
-| 2.10
+| 2.13
 |===
 
 This cop checks for the use of Time methods without zone.


### PR DESCRIPTION
Follow up to https://github.com/rubocop/rubocop-rails/pull/575#discussion_r726487516

This PR marks `Rails/TimeZone` as unsafe auto-correction from unsafe.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
