### PR TITLE
Mark `Rails/SafeNavigationWithBlank` as unsafe`

### DIFF
--- a/changelog/change_mark_rails_safe_navigation_with_blank_as_unsafe.md
+++ b/changelog/change_mark_rails_safe_navigation_with_blank_as_unsafe.md
@@ -1,0 +1,1 @@
+* [#577](https://github.com/rubocop/rubocop-rails/pull/577): Mark `Rails/SafeNavigationWithBlank` as unsafe. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -709,13 +709,14 @@ Rails/SafeNavigationWithBlank:
   Description: 'Avoid `foo&.blank?` in conditionals.'
   Enabled: true
   VersionAdded: '2.4'
+  VersionChanged: '2.13'
   # While the safe navigation operator is generally a good idea, when
   # checking `foo&.blank?` in a conditional, `foo` being `nil` will actually
   # do the opposite of what the author intends.
   #
   # foo&.blank? #=> nil
   # foo.blank? #=> true
-  SafeAutoCorrect: false
+  Safe: false
 
 Rails/SaveBang:
   Description: 'Identifies possible cases where Active Record save! or related should be used.'

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -4197,10 +4197,10 @@ foo&.bar { |e| e.baz }
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
 | Enabled
-| Yes
+| No
 | Yes (Unsafe)
 | 2.4
-| -
+| 2.13
 |===
 
 This cop checks to make sure safe navigation isn't used with `blank?` in


### PR DESCRIPTION
Follow up to https://github.com/rubocop/rubocop-rails/pull/575#discussion_r726454310.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
