### PR TITLE
Add missing deprecated `errors` methods

### DIFF
--- a/changelog/fix_deprecated_errors_missing_methods.md
+++ b/changelog/fix_deprecated_errors_missing_methods.md
@@ -1,0 +1,1 @@
+* [#742](https://github.com/rubocop/rubocop-rails/pull/742): Rails/DeprecatedActiveModelErrorsMethods was missing the deprecated `values`, `to_h`, and `to_xml` methods. ([@BrianHawley][])

--- a/lib/rubocop/cop/rails/deprecated_active_model_errors_methods.rb
+++ b/lib/rubocop/cop/rails/deprecated_active_model_errors_methods.rb
@@ -38,6 +38,7 @@ module RuboCop
 
         MSG = 'Avoid manipulating ActiveModel errors as hash directly.'
         AUTOCORRECTABLE_METHODS = %i[<< clear keys].freeze
+        INCOMPATIBLE_METHODS = %i[keys values to_h to_xml].freeze
 
         MANIPULATIVE_METHODS = Set[
           *%i[
@@ -55,7 +56,7 @@ module RuboCop
           {
             #root_manipulation?
             #root_assignment?
-            #errors_keys?
+            #errors_deprecated?
             #messages_details_manipulation?
             #messages_details_assignment?
           }
@@ -77,10 +78,10 @@ module RuboCop
             ...)
         PATTERN
 
-        def_node_matcher :errors_keys?, <<~PATTERN
+        def_node_matcher :errors_deprecated?, <<~PATTERN
           (send
             (send #receiver_matcher :errors)
-            :keys)
+            {:keys :values :to_h :to_xml})
         PATTERN
 
         def_node_matcher :messages_details_manipulation?, <<~PATTERN
@@ -106,7 +107,7 @@ module RuboCop
 
         def on_send(node)
           any_manipulation?(node) do
-            next if node.method?(:keys) && target_rails_version <= 6.0
+            next if target_rails_version <= 6.0 && INCOMPATIBLE_METHODS.include?(node.method_name)
 
             add_offense(node) do |corrector|
               next if skip_autocorrect?(node)

--- a/spec/rubocop/cop/rails/deprecated_active_model_errors_methods_spec.rb
+++ b/spec/rubocop/cop/rails/deprecated_active_model_errors_methods_spec.rb
@@ -64,6 +64,39 @@ RSpec.describe RuboCop::Cop::Rails::DeprecatedActiveModelErrorsMethods, :config 
             RUBY
           end
         end
+
+        context 'when using `values` method' do
+          it 'registers an offense' do
+            expect_offense(<<~RUBY, file_path)
+              user.errors.values
+              ^^^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
+            RUBY
+
+            expect_no_corrections
+          end
+        end
+
+        context 'when using `to_h` method' do
+          it 'registers an offense' do
+            expect_offense(<<~RUBY, file_path)
+              user.errors.to_h
+              ^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
+            RUBY
+
+            expect_no_corrections
+          end
+        end
+
+        context 'when using `to_xml` method' do
+          it 'registers an offense' do
+            expect_offense(<<~RUBY, file_path)
+              user.errors.to_xml
+              ^^^^^^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
+            RUBY
+
+            expect_no_corrections
+          end
+        end
       end
 
       context 'Rails <= 6.0', :rails60 do
@@ -78,6 +111,30 @@ RSpec.describe RuboCop::Cop::Rails::DeprecatedActiveModelErrorsMethods, :config 
           it 'does not register an offense when root receiver is a method' do
             expect_no_offenses(<<~RUBY, file_path)
               user.errors.keys.include?(:name)
+            RUBY
+          end
+        end
+
+        context 'when using `values` method' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<~RUBY, file_path)
+              user.errors.values
+            RUBY
+          end
+        end
+
+        context 'when using `to_h` method' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<~RUBY, file_path)
+              user.errors.to_h
+            RUBY
+          end
+        end
+
+        context 'when using `to_xml` method' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<~RUBY, file_path)
+              user.errors.to_xml
             RUBY
           end
         end
@@ -240,6 +297,39 @@ RSpec.describe RuboCop::Cop::Rails::DeprecatedActiveModelErrorsMethods, :config 
             RUBY
           end
         end
+
+        context 'when using `values` method' do
+          it 'registers an offense' do
+            expect_offense_if_model_file(<<~RUBY, file_path)
+              errors.values
+              ^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
+            RUBY
+
+            expect_no_corrections_if_model_file(file_path)
+          end
+        end
+
+        context 'when using `to_h` method' do
+          it 'registers an offense' do
+            expect_offense_if_model_file(<<~RUBY, file_path)
+              errors.to_h
+              ^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
+            RUBY
+
+            expect_no_corrections_if_model_file(file_path)
+          end
+        end
+
+        context 'when using `to_xml` method' do
+          it 'registers an offense' do
+            expect_offense_if_model_file(<<~RUBY, file_path)
+              errors.to_xml
+              ^^^^^^^^^^^^^ Avoid manipulating ActiveModel errors as hash directly.
+            RUBY
+
+            expect_no_corrections_if_model_file(file_path)
+          end
+        end
       end
 
       context 'Rails <= 6.0', :rails60 do
@@ -247,6 +337,30 @@ RSpec.describe RuboCop::Cop::Rails::DeprecatedActiveModelErrorsMethods, :config 
           it 'does not register an offense' do
             expect_no_offenses(<<~RUBY, file_path)
               errors.keys
+            RUBY
+          end
+        end
+
+        context 'when using `values` method' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<~RUBY, file_path)
+              user.errors.values
+            RUBY
+          end
+        end
+
+        context 'when using `to_h` method' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<~RUBY, file_path)
+              user.errors.to_h
+            RUBY
+          end
+        end
+
+        context 'when using `to_xml` method' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<~RUBY, file_path)
+              user.errors.to_xml
             RUBY
           end
         end


### PR DESCRIPTION
Fixes for Rails/DeprecatedActiveModelErrorsMethods:
- The `values`, `to_h`, and `to_xml` methods are deprecated too.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
