### PR TITLE
[Fix #1505] Fix false negatives for `Rails/Pluck`

### DIFF
--- a/changelog/fix_false_negatives_for_rails_pluck.md
+++ b/changelog/fix_false_negatives_for_rails_pluck.md
@@ -1,0 +1,1 @@
+* [#1505](https://github.com/rubocop/rubocop-rails/issues/1505): Fix false negatives for `Rails/Pluck` when `map` method call is used in a block without a receiver. ([@koic][])

--- a/lib/rubocop/cop/rails/pluck.rb
+++ b/lib/rubocop/cop/rails/pluck.rb
@@ -27,6 +27,9 @@ module RuboCop
       # end
       # ----
       #
+      # If a method call has no receiver, like `do_something { users.map { |user| user[:foo] }`,
+      # it is not considered part of an iteration and will be detected.
+      #
       # @safety
       #   This cop is unsafe because model can use column aliases.
       #
@@ -59,9 +62,9 @@ module RuboCop
           (any_block (call _ {:map :collect}) $_argument (send lvar :[] $_key))
         PATTERN
 
-        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def on_block(node)
-          return if node.each_ancestor(:any_block).any?
+          return if node.each_ancestor(:any_block).first&.receiver
 
           pluck_candidate?(node) do |argument, key|
             next if key.regexp_type? || !use_one_block_argument?(argument)
@@ -79,7 +82,7 @@ module RuboCop
             register_offense(node, key)
           end
         end
-        # rubocop:enable Metrics/AbcSize
+        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         alias on_numblock on_block
         alias on_itblock on_block
 

--- a/spec/rubocop/cop/rails/pluck_spec.rb
+++ b/spec/rubocop/cop/rails/pluck_spec.rb
@@ -154,7 +154,24 @@ RSpec.describe RuboCop::Cop::Rails::Pluck, :config do
         end
       end
 
-      context "when `#{method}` is used in block" do
+      context "when `#{method}` is used in a block without a receiver" do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY, method: method)
+            foo do
+              x.%{method} { |a| a[:foo] }
+                ^{method}^^^^^^^^^^^^^^^^ Prefer `pluck(:foo)` over `%{method} { |a| a[:foo] }`.
+            end
+          RUBY
+
+          expect_correction(<<~RUBY)
+            foo do
+              x.pluck(:foo)
+            end
+          RUBY
+        end
+      end
+
+      context "when `#{method}` is used in a repeatable block" do
         it 'does not register an offense' do
           expect_no_offenses(<<~RUBY)
             n.each do |x|
@@ -164,7 +181,7 @@ RSpec.describe RuboCop::Cop::Rails::Pluck, :config do
         end
       end
 
-      context "when `#{method}` is used in block with other operations" do
+      context "when `#{method}` is used in a repeatable block with other operations" do
         it 'does not register an offense' do
           expect_no_offenses(<<~RUBY)
             n.each do |x|
@@ -175,7 +192,7 @@ RSpec.describe RuboCop::Cop::Rails::Pluck, :config do
         end
       end
 
-      context "when `#{method}` is used in numblock" do
+      context "when `#{method}` is used in a repeatable numblock" do
         it 'does not register an offense' do
           expect_no_offenses(<<~RUBY)
             n.each do
@@ -185,7 +202,7 @@ RSpec.describe RuboCop::Cop::Rails::Pluck, :config do
         end
       end
 
-      context "when `#{method}` is used in numblock with other operations" do
+      context "when `#{method}` is used in reapeatable numblock with other operations" do
         it 'does not register an offense' do
           expect_no_offenses(<<~RUBY)
             n.each do


### PR DESCRIPTION
This PR fixes false negatives for `Rails/Pluck` when `map` method call is used in a block without a receiver.

Fixes #1505.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
