### PR TITLE
Don't register offenses for `Rails/WhereExists` when `exists?` is given multiple or splat arguments

### DIFF
--- a/changelog/fix_rails_where_exists_behavior_for_exists_with_multiple_arguments.md
+++ b/changelog/fix_rails_where_exists_behavior_for_exists_with_multiple_arguments.md
@@ -1,0 +1,1 @@
+* [#1511](https://github.com/rubocop/rubocop-rails/pull/1511): Don't register offenses for `Rails/WhereExists` when `exists?` is given multiple or splat arguments. ([@lovro-bikic][])

--- a/lib/rubocop/cop/rails/where_exists.rb
+++ b/lib/rubocop/cop/rails/where_exists.rb
@@ -58,8 +58,8 @@ module RuboCop
           (call (call _ :where $...) :exists?)
         PATTERN
 
-        def_node_matcher :exists_with_args?, <<~PATTERN
-          (call _ :exists? $...)
+        def_node_matcher :exists_with_arg?, <<~PATTERN
+          (call _ :exists? $!splat_type?)
         PATTERN
 
         def on_send(node)
@@ -91,7 +91,7 @@ module RuboCop
           if exists_style?
             where_exists_call?(node, &block)
           elsif where_style?
-            exists_with_args?(node, &block)
+            exists_with_arg?(node) { |arg| yield([arg]) }
           end
         end
 

--- a/spec/rubocop/cop/rails/where_exists_spec.rb
+++ b/spec/rubocop/cop/rails/where_exists_spec.rb
@@ -142,25 +142,26 @@ RSpec.describe RuboCop::Cop::Rails::WhereExists, :config do
       RUBY
     end
 
-    it 'registers an offense and corrects when using `exists?` with an multiple arguments' do
-      expect_offense(<<~RUBY)
+    it 'does not register an offense when using `exists?` with multiple arguments' do
+      expect_no_offenses(<<~RUBY)
         User.exists?('name = ?', 'john')
-             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `where('name = ?', 'john').exists?` over `exists?('name = ?', 'john')`.
       RUBY
+    end
 
-      expect_correction(<<~RUBY)
-        User.where('name = ?', 'john').exists?
+    it 'does not register an offense when using `exists?` with splat argument' do
+      expect_no_offenses(<<~RUBY)
+        User.exists?(*conditions)
       RUBY
     end
 
     it 'registers an offense when using implicit receiver and arg' do
       expect_offense(<<~RUBY)
-        exists?('name = ?', 'john')
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `where('name = ?', 'john').exists?` over `exists?('name = ?', 'john')`.
+        exists?(['name = ?', 'john'])
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `where(['name = ?', 'john']).exists?` over `exists?(['name = ?', 'john'])`.
       RUBY
 
       expect_correction(<<~RUBY)
-        where('name = ?', 'john').exists?
+        where(['name = ?', 'john']).exists?
       RUBY
     end
 


### PR DESCRIPTION
Changes `Rails/WhereExists` so it doesn't register offenses for either:
```
Model.exists?(multiple, arguments)
Model.exists?(*splat_arguments)
```
when `EnforcedStyle` is `where`.

[`exists?`](https://api.rubyonrails.org/classes/ActiveRecord/FinderMethods.html#method-i-exists-3F) method only accepts a single argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
