### PR TITLE
default config: only include paths relative to cwd

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -6,7 +6,7 @@ inherit_mode:
 
 AllCops:
   Exclude:
-    - '**/app/assets/**/*'
+    - '{,./**/}app/assets/**/*'
     - bin/*
     # Exclude db/schema.rb and db/[CONFIGURATION_NAMESPACE]_schema.rb by default.
     # See: https://guides.rubyonrails.org/active_record_multiple_databases.html#setting-up-your-application
@@ -94,8 +94,8 @@ Lint/UselessAccessModifier:
 Lint/UselessMethodDefinition:
   # Avoids conflict with `Rails/LexicallyScopedActionFilter` cop.
   Exclude:
-    - '**/app/controllers/**/*.rb'
-    - '**/app/mailers/**/*.rb'
+    - '{,./**/}app/controllers/**/*.rb'
+    - '{,./**/}app/mailers/**/*.rb'
 
 Rails:
   Enabled: true
@@ -115,7 +115,7 @@ Rails/ActionControllerTestCase:
   SafeAutoCorrect: false
   VersionAdded: '2.14'
   Include:
-    - '**/test/**/*.rb'
+    - '{,./**/}test/**/*.rb'
 
 Rails/ActionFilter:
   Description: 'Enforces consistent use of action filter methods.'
@@ -127,8 +127,8 @@ Rails/ActionFilter:
     - action
     - filter
   Include:
-    - '**/app/controllers/**/*.rb'
-    - '**/app/mailers/**/*.rb'
+    - '{,./**/}app/controllers/**/*.rb'
+    - '{,./**/}app/mailers/**/*.rb'
 
 Rails/ActionOrder:
   Description: 'Enforce consistent ordering of controller actions.'
@@ -143,7 +143,7 @@ Rails/ActionOrder:
     - update
     - destroy
   Include:
-    - '**/app/controllers/**/*.rb'
+    - '{,./**/}app/controllers/**/*.rb'
 
 Rails/ActiveRecordAliases:
   Description: >-
@@ -160,7 +160,7 @@ Rails/ActiveRecordCallbacksOrder:
   Enabled: 'pending'
   VersionAdded: '2.7'
   Include:
-    - '**/app/models/**/*.rb'
+    - '{,./**/}app/models/**/*.rb'
 
 Rails/ActiveRecordOverride:
   Description: >-
@@ -171,7 +171,7 @@ Rails/ActiveRecordOverride:
   VersionAdded: '0.67'
   VersionChanged: '2.18'
   Include:
-    - '**/app/models/**/*.rb'
+    - '{,./**/}app/models/**/*.rb'
 
 Rails/ActiveSupportAliases:
   Description: >-
@@ -251,14 +251,14 @@ Rails/AssertNot:
   Enabled: true
   VersionAdded: '0.56'
   Include:
-    - '**/test/**/*'
+    - '{,./**/}test/**/*'
 
 Rails/AttributeDefaultBlockValue:
   Description: 'Pass method call in block for attribute option `default`.'
   Enabled: pending
   VersionAdded: '2.9'
   Include:
-    - '**/app/models/**/*'
+    - '{,./**/}app/models/**/*'
 
 Rails/BelongsTo:
   Description: >-
@@ -317,8 +317,8 @@ Rails/ContentTag:
   # https://puma.io/puma/Puma/DSL.html#tag-instance_method
   # No helpers are used in normal models and configs.
   Exclude:
-    - '**/app/models/**/*.rb'
-    - '**/config/**/*.rb'
+    - '{,./**/}app/models/**/*.rb'
+    - '{,./**/}config/**/*.rb'
 
 Rails/CreateTableWithTimestamps:
   Description: >-
@@ -379,7 +379,7 @@ Rails/Delegate:
   # violation. When set to false, this case is legal.
   EnforceForPrefixed: true
   Exclude:
-    - '**/app/controllers/**/*.rb'
+    - '{,./**/}app/controllers/**/*.rb'
 
 Rails/DelegateAllowBlank:
   Description: 'Do not use allow_blank as an option to delegate.'
@@ -450,7 +450,7 @@ Rails/EnumHash:
   Enabled: true
   VersionAdded: '2.3'
   Include:
-    - '**/app/models/**/*.rb'
+    - '{,./**/}app/models/**/*.rb'
 
 Rails/EnumSyntax:
   Description: 'Use positional arguments over keyword arguments when defining enums.'
@@ -458,15 +458,15 @@ Rails/EnumSyntax:
   Severity: warning
   VersionAdded: '2.26'
   Include:
-    - '**/app/models/**/*.rb'
-    - '**/lib/**/*.rb'
+    - '{,./**/}app/models/**/*.rb'
+    - '{,./**/}lib/**/*.rb'
 
 Rails/EnumUniqueness:
   Description: 'Avoid duplicate integers in hash-syntax `enum` declaration.'
   Enabled: true
   VersionAdded: '0.46'
   Include:
-    - '**/app/models/**/*.rb'
+    - '{,./**/}app/models/**/*.rb'
 
 Rails/EnvLocal:
   Description: 'Use `Rails.env.local?` instead of `Rails.env.development? || Rails.env.test?`.'
@@ -485,11 +485,11 @@ Rails/EnvironmentVariableAccess:
   VersionAdded: '2.10'
   VersionChanged: '2.24'
   Include:
-    - '**/app/**/*.rb'
-    - '**/config/initializers/**/*.rb'
-    - '**/lib/**/*.rb'
+    - '{,./**/}app/**/*.rb'
+    - '{,./**/}config/initializers/**/*.rb'
+    - '{,./**/}lib/**/*.rb'
   Exclude:
-    - '**/lib/**/*.rake'
+    - '{,./**/}lib/**/*.rake'
   AllowReads: false
   AllowWrites: false
 
@@ -501,11 +501,11 @@ Rails/Exit:
   Enabled: true
   VersionAdded: '0.41'
   Include:
-    - '**/app/**/*.rb'
-    - '**/config/**/*.rb'
-    - '**/lib/**/*.rb'
+    - '{,./**/}app/**/*.rb'
+    - '{,./**/}config/**/*.rb'
+    - '{,./**/}lib/**/*.rb'
   Exclude:
-    - '**/lib/**/*.rake'
+    - '{,./**/}lib/**/*.rake'
 
 Rails/ExpandedDateRange:
   Description: 'Checks for expanded date range.'
@@ -574,7 +574,7 @@ Rails/HasAndBelongsToMany:
   Enabled: true
   VersionAdded: '0.12'
   Include:
-    - '**/app/models/**/*.rb'
+    - '{,./**/}app/models/**/*.rb'
 
 Rails/HasManyOrHasOneDependent:
   Description: 'Define the dependent option to the has_many and has_one associations.'
@@ -582,14 +582,14 @@ Rails/HasManyOrHasOneDependent:
   Enabled: true
   VersionAdded: '0.50'
   Include:
-    - '**/app/models/**/*.rb'
+    - '{,./**/}app/models/**/*.rb'
 
 Rails/HelperInstanceVariable:
   Description: 'Do not use instance variables in helpers.'
   Enabled: true
   VersionAdded: '2.0'
   Include:
-    - '**/app/helpers/**/*.rb'
+    - '{,./**/}app/helpers/**/*.rb'
 
 Rails/HttpPositionalArguments:
   Description: 'Use keyword arguments instead of positional arguments in http method calls.'
@@ -620,7 +620,7 @@ Rails/I18nLazyLookup:
     - lazy
     - explicit
   Include:
-    - '**/app/controllers/**/*.rb'
+    - '{,./**/}app/controllers/**/*.rb'
 
 Rails/I18nLocaleAssignment:
   Description: 'Prefer the usage of `I18n.with_locale` instead of manually updating `I18n.locale` value.'
@@ -649,8 +649,8 @@ Rails/IgnoredSkipActionFilterOption:
   Enabled: true
   VersionAdded: '0.63'
   Include:
-    - '**/app/controllers/**/*.rb'
-    - '**/app/mailers/**/*.rb'
+    - '{,./**/}app/controllers/**/*.rb'
+    - '{,./**/}app/mailers/**/*.rb'
 
 Rails/IndexBy:
   Description: 'Prefer `index_by` over `each_with_object`, `to_h`, or `map`.'
@@ -680,7 +680,7 @@ Rails/InverseOf:
   VersionAdded: '0.52'
   IgnoreScopes: false
   Include:
-    - '**/app/models/**/*.rb'
+    - '{,./**/}app/models/**/*.rb'
 
 Rails/LexicallyScopedActionFilter:
   Description: "Checks that methods specified in the filter's `only` or `except` options are explicitly defined in the class."
@@ -689,8 +689,8 @@ Rails/LexicallyScopedActionFilter:
   Safe: false
   VersionAdded: '0.52'
   Include:
-    - '**/app/controllers/**/*.rb'
-    - '**/app/mailers/**/*.rb'
+    - '{,./**/}app/controllers/**/*.rb'
+    - '{,./**/}app/mailers/**/*.rb'
 
 Rails/LinkToBlank:
   Description: 'Checks that `link_to` with a `target: "_blank"` have a `rel: "noopener"` option passed to them.'
@@ -708,7 +708,7 @@ Rails/MailerName:
   SafeAutoCorrect: false
   VersionAdded: '2.7'
   Include:
-    - '**/app/mailers/**/*.rb'
+    - '{,./**/}app/mailers/**/*.rb'
 
 Rails/MatchRoute:
   Description: >-
@@ -718,8 +718,8 @@ Rails/MatchRoute:
   Enabled: 'pending'
   VersionAdded: '2.7'
   Include:
-    - '**/config/routes.rb'
-    - '**/config/routes/**/*.rb'
+    - '{,./**/}config/routes.rb'
+    - '{,./**/}config/routes/**/*.rb'
 
 Rails/MigrationClassName:
   Description: 'The class name of the migration should match its file name.'
@@ -735,8 +735,8 @@ Rails/MultipleRoutePaths:
   Severity: warning
   VersionAdded: '2.29'
   Include:
-    - '**/config/routes.rb'
-    - '**/config/routes/**/*.rb'
+    - '{,./**/}config/routes.rb'
+    - '{,./**/}config/routes/**/*.rb'
 
 Rails/NegateInclude:
   Description: 'Prefer `collection.exclude?(obj)` over `!collection.include?(obj)`.'
@@ -779,10 +779,10 @@ Rails/Output:
   VersionAdded: '0.15'
   VersionChanged: '0.19'
   Include:
-    - '**/app/**/*.rb'
-    - '**/config/**/*.rb'
+    - '{,./**/}app/**/*.rb'
+    - '{,./**/}config/**/*.rb'
     - db/**/*.rb
-    - '**/lib/**/*.rb'
+    - '{,./**/}lib/**/*.rb'
 
 Rails/OutputSafety:
   Description: 'The use of `html_safe` or `raw` may be a security risk.'
@@ -851,10 +851,10 @@ Rails/RakeEnvironment:
   VersionAdded: '2.4'
   VersionChanged: '2.6'
   Include:
-    - '**/Rakefile'
-    - '**/*.rake'
+    - '{,./**/}Rakefile'
+    - '{,./**/}*.rake'
   Exclude:
-    - '**/lib/capistrano/tasks/**/*.rake'
+    - '{,./**/}lib/capistrano/tasks/**/*.rake'
 
 Rails/ReadWriteAttribute:
   Description: >-
@@ -865,7 +865,7 @@ Rails/ReadWriteAttribute:
   VersionAdded: '0.20'
   VersionChanged: '0.29'
   Include:
-    - '**/app/models/**/*.rb'
+    - '{,./**/}app/models/**/*.rb'
 
 Rails/RedundantActiveRecordAllMethod:
   Description: Detect redundant `all` used as a receiver for Active Record query methods.
@@ -884,7 +884,7 @@ Rails/RedundantAllowNil:
   Enabled: true
   VersionAdded: '0.67'
   Include:
-    - '**/app/models/**/*.rb'
+    - '{,./**/}app/models/**/*.rb'
 
 Rails/RedundantForeignKey:
   Description: 'Checks for associations where the `:foreign_key` option is redundant.'
@@ -926,7 +926,7 @@ Rails/RefuteMethods:
     - assert_not
     - refute
   Include:
-    - '**/test/**/*'
+    - '{,./**/}test/**/*'
 
 Rails/RelativeDateConstant:
   Description: 'Do not assign relative date to constants.'
@@ -1055,7 +1055,7 @@ Rails/ScopeArgs:
   VersionAdded: '0.19'
   VersionChanged: '2.12'
   Include:
-    - '**/app/models/**/*.rb'
+    - '{,./**/}app/models/**/*.rb'
 
 Rails/SelectMap:
   Description: 'Checks for uses of `select(:column_name)` with `map(&:column_name)`.'
@@ -1124,7 +1124,7 @@ Rails/StrongParametersExpect:
   Reference: 'https://api.rubyonrails.org/classes/ActionController/Parameters.html#method-i-expect'
   Enabled: pending
   Include:
-    - '**/app/controllers/**/*.rb'
+    - '{,./**/}app/controllers/**/*.rb'
   SafeAutoCorrect: false
   VersionAdded: '2.29'
 
@@ -1135,7 +1135,7 @@ Rails/TableNameAssignment:
   Enabled: false
   VersionAdded: '2.14'
   Include:
-    - '**/app/models/**/*.rb'
+    - '{,./**/}app/models/**/*.rb'
 
 Rails/ThreeStateBooleanColumn:
   Description: 'Add a default value and a `NOT NULL` constraint to boolean columns.'
@@ -1160,7 +1160,7 @@ Rails/TimeZone:
     - strict
     - flexible
   Exclude:
-    - '**/*.gemspec'
+    - '{,./**/}*.gemspec'
 
 Rails/TimeZoneAssignment:
   Description: 'Prefer the usage of `Time.use_zone` instead of manually updating `Time.zone` value.'
@@ -1219,7 +1219,7 @@ Rails/UniqueValidationWithoutIndex:
   Enabled: true
   VersionAdded: '2.5'
   Include:
-    - '**/app/models/**/*.rb'
+    - '{,./**/}app/models/**/*.rb'
 
 Rails/UnknownEnv:
   Description: 'Use correct environment name.'
@@ -1238,7 +1238,7 @@ Rails/UnusedIgnoredColumns:
   VersionAdded: '2.11'
   VersionChanged: '2.25'
   Include:
-    - '**/app/models/**/*.rb'
+    - '{,./**/}app/models/**/*.rb'
 
 Rails/UnusedRenderContent:
   Description: 'Do not specify body content for a response with a non-content status code.'
@@ -1252,7 +1252,7 @@ Rails/Validation:
   VersionAdded: '0.9'
   VersionChanged: '0.41'
   Include:
-    - '**/app/models/**/*.rb'
+    - '{,./**/}app/models/**/*.rb'
 
 Rails/WhereEquals:
   Description: 'Pass conditions to `where` and `where.not` as a hash instead of manually constructing SQL.'

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -158,13 +158,15 @@ RSpec.describe 'RuboCop Rails Project', type: :feature do
           next if config[name][clusivity_key].nil?
 
           config[name][clusivity_key].each do |clusivity_pattern|
-            expect(clusivity_pattern).to match(%r{\*\*/app/}), <<~ERROR if clusivity_pattern.match?(%r{\bapp/})
+            expect(clusivity_pattern).to match(%r{\{,./\*\*/\}app/}), <<~ERROR if clusivity_pattern.match?(%r{\bapp/})
               Invalid pattern for #{name} #{clusivity_key}: #{clusivity_pattern}
             ERROR
-            expect(clusivity_pattern).to match(%r{\*\*/config/}), <<~ERROR if clusivity_pattern.match?(%r{\bconfig/})
-              Invalid pattern for #{name} #{clusivity_key}: #{clusivity_pattern}
-            ERROR
-            expect(clusivity_pattern).to match(%r{\*\*/lib/}), <<~ERROR if clusivity_pattern.match?(%r{\blib/})
+            if clusivity_pattern.match?(%r{\bconfig/})
+              expect(clusivity_pattern).to match(%r{\{,./\*\*/\}config/}), <<~ERROR
+                Invalid pattern for #{name} #{clusivity_key}: #{clusivity_pattern}
+              ERROR
+            end
+            expect(clusivity_pattern).to match(%r{\{,./\*\*/\}lib/}), <<~ERROR if clusivity_pattern.match?(%r{\blib/})
               Invalid pattern for #{name} #{clusivity_key}: #{clusivity_pattern}
             ERROR
           end


### PR DESCRIPTION
The default include patterns also matched folders outside the current working directory. When my app lives in `/srv/app` the pattern `**/app/**/*.rb` also matches the file `spec/rails_helper.rb`, because the absolute path (`/srv/app/spec/rails_helper.rb`) matches the pattern. This is unintended. The PR ensures that only app folders inside the projects directory are recognized.


Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
