### PR TITLE
Fix an incorrect autocorrect for `Rails/FindByOrAssignmentMemoization`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_rails_find_by_or_assignment_memoization.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_rails_find_by_or_assignment_memoization.md
@@ -1,0 +1,1 @@
+* [#1530](https://github.com/rubocop/rubocop-rails/issues/1530): Fix an incorrect autocorrect for `Rails/FindByOrAssignmentMemoization` when using endless method definition. ([@koic][])

--- a/lib/rubocop/cop/rails/find_by_or_assignment_memoization.rb
+++ b/lib/rubocop/cop/rails/find_by_or_assignment_memoization.rb
@@ -62,10 +62,12 @@ module RuboCop
                 node.body,
                 <<~RUBY.rstrip
                   return #{varible_name} if defined?(#{varible_name})
-                  
+
                   #{varible_name} = #{find_by.source}
                 RUBY
               )
+
+              correct_to_regular_method_definition(corrector, node) if node.endless?
             end
           end
         end
@@ -88,6 +90,15 @@ module RuboCop
               )
             end
           end
+        end
+
+        private
+
+        def correct_to_regular_method_definition(corrector, node)
+          range = node.loc.assignment.join(node.body.source_range.begin)
+
+          corrector.replace(range, "\n")
+          corrector.insert_after(node, "\nend")
         end
       end
     end


### PR DESCRIPTION
This PR fixes an incorrect autocorrect for `Rails/FindByOrAssignmentMemoization` when using endless method definition.

Fixes #1530.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
