### PR TITLE
Add `abort` to the `Rails/Exit` cop

### DIFF
--- a/changelog/change_add_abort_to_rails_exit.md
+++ b/changelog/change_add_abort_to_rails_exit.md
@@ -1,0 +1,1 @@
+* [#1537](https://github.com/rubocop/rubocop-rails/pull/1537): Add `abort` to the `Rails/Exit` cop. ([@adamstegman][])

--- a/lib/rubocop/cop/rails/exit.rb
+++ b/lib/rubocop/cop/rails/exit.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Rails
-      # Enforces that `exit` calls are not used within a rails app.
+      # Enforces that `exit` and `abort` calls are not used within a rails app.
       # Valid options are instead to raise an error, break, return, or some
       # other form of stopping execution of current request.
       #
@@ -26,12 +26,15 @@ module RuboCop
       class Exit < Base
         include ConfigurableEnforcedStyle
 
-        MSG = 'Do not use `exit` in Rails applications.'
-        RESTRICT_ON_SEND = %i[exit exit!].freeze
+        MSG = 'Do not use `%<current>s` in Rails applications.'
+        RESTRICT_ON_SEND = %i[exit exit! abort].freeze
         EXPLICIT_RECEIVERS = %i[Kernel Process].freeze
 
         def on_send(node)
-          add_offense(node.loc.selector) if offending_node?(node)
+          return unless offending_node?(node)
+
+          message = format(MSG, current: node.method_name)
+          add_offense(node.loc.selector, message: message)
         end
 
         private

--- a/spec/rubocop/cop/rails/exit_spec.rb
+++ b/spec/rubocop/cop/rails/exit_spec.rb
@@ -11,7 +11,14 @@ RSpec.describe RuboCop::Cop::Rails::Exit, :config do
   it 'registers an offense for an exit! call with no receiver' do
     expect_offense(<<~RUBY)
       exit!
-      ^^^^^ Do not use `exit` in Rails applications.
+      ^^^^^ Do not use `exit!` in Rails applications.
+    RUBY
+  end
+
+  it 'registers an offense for an abort call with no receiver' do
+    expect_offense(<<~RUBY)
+      abort
+      ^^^^^ Do not use `abort` in Rails applications.
     RUBY
   end
 
@@ -27,6 +34,10 @@ RSpec.describe RuboCop::Cop::Rails::Exit, :config do
     it 'does not register an offense for an explicit exit! call on an object' do
       expect_no_offenses('Object.new.exit!(0)')
     end
+
+    it 'does not register an offense for an explicit abort call on an object' do
+      expect_no_offenses('Object.new.abort("failed")')
+    end
   end
 
   context 'with arguments' do
@@ -39,6 +50,17 @@ RSpec.describe RuboCop::Cop::Rails::Exit, :config do
 
     it 'ignores exit calls with unexpected number of parameters' do
       expect_no_offenses('exit(1, 2)')
+    end
+
+    it 'registers an offense for an abort("message") call with no receiver' do
+      expect_offense(<<~RUBY)
+        abort("message")
+        ^^^^^ Do not use `abort` in Rails applications.
+      RUBY
+    end
+
+    it 'ignores abort calls with unexpected number of parameters' do
+      expect_no_offenses('abort("message", "another message")')
     end
   end
 
@@ -54,6 +76,20 @@ RSpec.describe RuboCop::Cop::Rails::Exit, :config do
       expect_offense(<<~RUBY)
         Process.exit
                 ^^^^ Do not use `exit` in Rails applications.
+      RUBY
+    end
+
+    it 'does register an offense for explicit Kernel.abort calls' do
+      expect_offense(<<~RUBY)
+        Kernel.abort
+               ^^^^^ Do not use `abort` in Rails applications.
+      RUBY
+    end
+
+    it 'does register an offense for explicit Process.abort calls' do
+      expect_offense(<<~RUBY)
+        Process.abort
+                ^^^^^ Do not use `abort` in Rails applications.
       RUBY
     end
   end


### PR DESCRIPTION
`abort` is very similar to `exit` in Ruby ([docs](https://docs.ruby-lang.org/en/3.4/Kernel.html#method-i-abort)), but it takes a string message or Exception. Rails applications should avoid its usage for the same reasons as they avoid `exit` and `exit!`. Since they are used in the same way, I thought it belonged in the same cop, but am glad to move it to a new one if that's preferred.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
