### PR TITLE
Change `Rails/HelperInstanceVariable` not to detect offenses for ivars within classes

### DIFF
--- a/changelog/change_rails_helper_instance_variable_not_to_detect_ivars_within_class.md
+++ b/changelog/change_rails_helper_instance_variable_not_to_detect_ivars_within_class.md
@@ -1,0 +1,1 @@
+* [#1525](https://github.com/rubocop/rubocop-rails/issues/1525): Change `Rails::HelperInstanceVariable` not to detect offenses for instance variables within classes. ([@viralpraxis][])

--- a/spec/rubocop/cop/rails/helper_instance_variable_spec.rb
+++ b/spec/rubocop/cop/rails/helper_instance_variable_spec.rb
@@ -57,14 +57,17 @@ RSpec.describe RuboCop::Cop::Rails::HelperInstanceVariable, :config do
     RUBY
   end
 
-  it 'registers an offense when using a class which does not inherit `ActionView::Helpers::FormBuilder`' do
-    expect_offense(<<~RUBY)
-      class Foo
-        def do_something
-          @template
-          ^^^^^^^^^ Do not use instance variables in helpers.
-          @template = do_something
-          ^^^^^^^^^ Do not use instance variables in helpers.
+  it 'does not register an offense when an instance variable is defined within a class' do
+    expect_no_offenses(<<~RUBY)
+      module ButtonHelper
+        class Button
+          def initialize(text:)
+            @text = text
+          end
+        end
+
+        def button(**args)
+          render Button.new(**args)
         end
       end
     RUBY


### PR DESCRIPTION
Resolves https://github.com/rubocop/rubocop-rails/issues/1525

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
