### PR TITLE
[Fix #1539] Fix an error for `Rails/ActionControllerFlashBeforeRender`

### DIFF
--- a/changelog/fix_an_error_for_rails_action_controller_flash_before_render.md
+++ b/changelog/fix_an_error_for_rails_action_controller_flash_before_render.md
@@ -1,0 +1,1 @@
+* [#1539](https://github.com/rubocop/rubocop-rails/issues/1539): Fix an error in `Rails/ActionControllerFlashBeforeRender` when `flash` is used inside a block followed by method chaining. ([@koic][])

--- a/lib/rubocop/cop/rails/action_controller_flash_before_render.rb
+++ b/lib/rubocop/cop/rails/action_controller_flash_before_render.rb
@@ -98,7 +98,9 @@ module RuboCop
         end
 
         def use_redirect_to?(context)
-          context.right_siblings.compact.any? do |sibling|
+          context.right_siblings.any? do |sibling|
+            next unless sibling.is_a?(AST::Node)
+
             # Unwrap `return redirect_to :index`
             sibling = sibling.children.first if sibling.return_type? && sibling.children.one?
             sibling.send_type? && sibling.method?(:redirect_to)

--- a/spec/rubocop/cop/rails/action_controller_flash_before_render_spec.rb
+++ b/spec/rubocop/cop/rails/action_controller_flash_before_render_spec.rb
@@ -427,4 +427,16 @@ RSpec.describe RuboCop::Cop::Rails::ActionControllerFlashBeforeRender, :config d
       RUBY
     end
   end
+
+  context 'when `flash` is used inside a block followed by method chaining' do
+    it 'does not register an offense and corrects' do
+      expect_no_offenses(<<~RUBY)
+        class NonController < ApplicationRecord
+          before_action do
+            flash[:notice] = 'hello'
+          end.do_something
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes an error in `Rails/ActionControllerFlashBeforeRender` when `flash` is used inside a block followed by method chaining.

Fixes #1539.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
