### PR TITLE
Remove CI workaround for Ruby 2.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,6 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gemspec
 
 gem 'bump', require: false
-# FIXME: Remove when the next prism version is released.
-gem 'prism', '< 1.5.0' if RUBY_VERSION < '3.0' || RUBY_ENGINE == 'jruby'
 gem 'rake'
 gem 'rspec'
 gem 'rubocop', github: 'rubocop/rubocop'


### PR DESCRIPTION
ref: https://github.com/rubocop/rubocop/pull/14593

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
[1]: https://chris.beams.io/posts/git-commit/
