### PR TITLE
Change `Rails/DuplicateScope` cop description

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -408,7 +408,7 @@ Rails/DuplicateAssociation:
   VersionChanged: '2.18'
 
 Rails/DuplicateScope:
-  Description: 'Multiple scopes share this same where clause.'
+  Description: 'Multiple scopes share this same expression.'
   Enabled: pending
   Severity: warning
   VersionAdded: '2.14'

--- a/lib/rubocop/cop/rails/duplicate_scope.rb
+++ b/lib/rubocop/cop/rails/duplicate_scope.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Rails
-      # Checks for multiple scopes in a model that have the same `where` clause. This
+      # Checks for multiple scopes in a model that have the same expression. This
       # often means you copy/pasted a scope, updated the name, and forgot to change the condition.
       #
       # @example
@@ -19,7 +19,7 @@ module RuboCop
       class DuplicateScope < Base
         include ClassSendNodeHelper
 
-        MSG = 'Multiple scopes share this same where clause.'
+        MSG = 'Multiple scopes share this same expression.'
 
         def_node_matcher :scope, <<~PATTERN
           (send nil? :scope _ $...)

--- a/spec/rubocop/cop/rails/duplicate_scope_spec.rb
+++ b/spec/rubocop/cop/rails/duplicate_scope_spec.rb
@@ -1,15 +1,28 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Rails::DuplicateScope, :config do
-  it 'registers an offense when a duplicate scope is detected' do
+  it 'registers an offense when a duplicate scope with the same `where` clauses is detected' do
     expect_offense(<<~RUBY)
       class Post < ApplicationRecord
         scope :visible, -> { where(visible: true) }
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Multiple scopes share this same where clause.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Multiple scopes share this same expression.
         scope :hidden, -> { where(visible: true) }
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Multiple scopes share this same where clause.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Multiple scopes share this same expression.
         scope :new, -> { where(created_at: 1.week.ago..Date.current) }
         scope :popular, -> { where(comments_count: 1000..Float::INFINITY) }
+      end
+    RUBY
+  end
+
+  it 'registers an offense when a duplicate scope with the same expression is detected' do
+    expect_offense(<<~RUBY)
+      class Post < ApplicationRecord
+        scope :with_visibility, ->(value) { where(visible: value) }
+
+        scope :visible, -> { with_visibility(true) }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Multiple scopes share this same expression.
+        scope :hidden, -> { with_visibility(true) }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Multiple scopes share this same expression.
       end
     RUBY
   end


### PR DESCRIPTION
It was not clear (for me) from the previous description that this cop actually matches duplicated scopes by their expressions, not just the `where` clauses.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
