### PR TITLE
Fix `Rails/InverseOf` cop false positives when using dynamic assoc options

### DIFF
--- a/changelog/fix_rails_inverse_of_cop_false_positives_when_using_dynamic_association_options.md
+++ b/changelog/fix_rails_inverse_of_cop_false_positives_when_using_dynamic_association_options.md
@@ -1,0 +1,1 @@
+* [#1549](https://github.com/rubocop/rubocop-rails/pull/1549): Fix `Rails/InverseOf` cop false positives when using dynamic association options. ([@viralpraxis][])

--- a/lib/rubocop/cop/rails/inverse_of.rb
+++ b/lib/rubocop/cop/rails/inverse_of.rb
@@ -178,6 +178,7 @@ module RuboCop
           (pair (sym :inverse_of) nil)
         PATTERN
 
+        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def on_send(node)
           recv, arguments = association_recv_arguments(node)
           return unless arguments
@@ -192,9 +193,11 @@ module RuboCop
           return unless scope?(arguments) || options_requiring_inverse_of?(options)
 
           return if options_contain_inverse_of?(options)
+          return if dynamic_options?(options) && options.none? { |opt| inverse_of_nil_option?(opt) }
 
           add_offense(node.loc.selector, message: message(options))
         end
+        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         def scope?(arguments)
           !ignore_scopes? && arguments.any?(&:block_type?)
@@ -214,6 +217,10 @@ module RuboCop
           options.any? do |opt|
             through_option?(opt) || polymorphic_option?(opt)
           end
+        end
+
+        def dynamic_options?(options)
+          options.any? { |option| option&.kwsplat_type? }
         end
 
         def options_contain_inverse_of?(options)

--- a/spec/rubocop/cop/rails/inverse_of_spec.rb
+++ b/spec/rubocop/cop/rails/inverse_of_spec.rb
@@ -24,6 +24,17 @@ RSpec.describe RuboCop::Cop::Rails::InverseOf, :config do
       RUBY
     end
 
+    it 'registers an offense when specifying `inverse_of: nil` with dynamic options' do
+      expect_offense(<<~RUBY)
+        class Person
+          def define_association(**options)
+            has_many :foo, -> () { where(bar: true) }, inverse_of: nil, **options
+            ^^^^^^^^ You specified `inverse_of: nil`, you probably meant to use `inverse_of: false`.
+          end
+        end
+      RUBY
+    end
+
     context 'when `IgnoreScopes: true`' do
       let(:cop_config) do
         { 'IgnoreScopes' => true }
@@ -70,6 +81,16 @@ RSpec.describe RuboCop::Cop::Rails::InverseOf, :config do
         end
       RUBY
     end
+
+    it 'does not register an offense with dynamic options' do
+      expect_no_offenses(<<~RUBY)
+        class Person
+          def define_association(**options)
+            has_many :foo, conditions: -> { where(bar: true) }, **options
+          end
+        end
+      RUBY
+    end
   end
 
   context 'with scope and options' do
@@ -78,6 +99,16 @@ RSpec.describe RuboCop::Cop::Rails::InverseOf, :config do
         class Person
           has_many :foo, -> { group 'x' }, dependent: :destroy
           ^^^^^^^^ Specify an `:inverse_of` option.
+        end
+      RUBY
+    end
+
+    it 'does not register an offense with dynamic options' do
+      expect_no_offenses(<<~RUBY)
+        class Person
+          def define_association(**options)
+            has_many(:foo, -> { group 'x' }, dependent: :destroy, **options)
+          end
         end
       RUBY
     end


### PR DESCRIPTION
Since dynamic options might contain `inverse_of`, I think it'd be better not to register an offense in such cases.

I tried hard to figure out what's the best way to change the cop without disabling half of the `Metrics` cops, but just gave up eventually

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.


[1]: https://chris.beams.io/posts/git-commit/
