### PR TITLE
[Fix #1553] Fix false positives for `Rails/OutputSafety`

### DIFF
--- a/changelog/fix_false_positive_for_rails_output_safety.md
+++ b/changelog/fix_false_positive_for_rails_output_safety.md
@@ -1,0 +1,1 @@
+* [#1553](https://github.com/rubocop/rubocop-rails/issues/1553): Fix false positives for `Rails/OutputSafety` when using non-interpolated multiline heredoc. ([@koic][])

--- a/lib/rubocop/cop/rails/output_safety.rb
+++ b/lib/rubocop/cop/rails/output_safety.rb
@@ -84,7 +84,9 @@ module RuboCop
         private
 
         def non_interpolated_string?(node)
-          node.receiver&.str_type? && !node.receiver.dstr_type?
+          return false unless (receiver = node.receiver)
+
+          receiver.str_type? || (receiver.dstr_type? && receiver.children.all?(&:str_type?))
         end
 
         def looks_like_rails_html_safe?(node)

--- a/spec/rubocop/cop/rails/output_safety_spec.rb
+++ b/spec/rubocop/cop/rails/output_safety_spec.rb
@@ -40,6 +40,42 @@ RSpec.describe RuboCop::Cop::Rails::OutputSafety, :config do
       RUBY
     end
 
+    it 'does not register an offense for static single line heredoc receiver' do
+      expect_no_offenses(<<~RUBY)
+        <<~HTML.html_safe
+          foo
+        HTML
+      RUBY
+    end
+
+    it 'registers an offense for dynamic single line heredoc receiver' do
+      expect_offense(<<~'RUBY')
+        <<~HTML.html_safe
+                ^^^^^^^^^ Tagging a string as html safe may be a security risk.
+          #{foo}
+        HTML
+      RUBY
+    end
+
+    it 'does not register an offense for static multiline heredoc receiver' do
+      expect_no_offenses(<<~RUBY)
+        <<~HTML.html_safe
+          foo
+          bar
+        HTML
+      RUBY
+    end
+
+    it 'registers an offense for dynamic multiline heredoc receiver' do
+      expect_offense(<<~'RUBY')
+        <<~HTML.html_safe
+                ^^^^^^^^^ Tagging a string as html safe may be a security risk.
+          foo
+          #{bar}
+        HTML
+      RUBY
+    end
+
     it 'registers an offense for variable receiver' do
       expect_offense(<<~RUBY)
         foo.html_safe


### PR DESCRIPTION
This PR fixes false positives for `Rails/OutputSafety` when using non-interpolated multiline heredoc.

Fixes #1553.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
