### PR TITLE
Fix an error for `Rails/Env`

### DIFF
--- a/changelog/fix_an_error_for_rails_env.md
+++ b/changelog/fix_an_error_for_rails_env.md
@@ -1,0 +1,1 @@
+* [#1556](https://github.com/rubocop/rubocop-rails/pull/1556): Fix an error for `Rails/Env` when assigning `Rails.env`. ([@koic][])

--- a/lib/rubocop/cop/rails/env.rb
+++ b/lib/rubocop/cop/rails/env.rb
@@ -45,7 +45,7 @@ module RuboCop
           return unless node.receiver&.const_name == 'Rails'
 
           parent = node.parent
-          return unless parent&.predicate_method?
+          return unless parent.respond_to?(:predicate_method?) && parent.predicate_method?
 
           return if ALLOWED_LIST.include?(parent.method_name)
 

--- a/spec/rubocop/cop/rails/env_spec.rb
+++ b/spec/rubocop/cop/rails/env_spec.rb
@@ -22,6 +22,12 @@ RSpec.describe RuboCop::Cop::Rails::Env, :config do
     RUBY
   end
 
+  it 'does not register an offense when assigning `Rails.env`' do
+    expect_no_offenses(<<~RUBY)
+      rails_env = Rails.env
+    RUBY
+  end
+
   it 'does not register an offense for valid Rails.env methods' do
     expect_no_offenses(<<~RUBY)
       Rails.env.capitalize


### PR DESCRIPTION
Follow-up to https://github.com/rubocop/rubocop-rails/issues/1376#issuecomment-3542938885.

This PR fixes an error for `Rails/Env` when assigning `Rails.env`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
