### PR TITLE
[Fix #1558] Fix incorrect autocorrect for `Rails/RedirectBackOrTo`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_rails_redirect_back_or_to.md
+++ b/changelog/fix_incorrect_autocorrect_for_rails_redirect_back_or_to.md
@@ -1,0 +1,1 @@
+* [#1558](https://github.com/rubocop/rubocop-rails/issues/1558): This PR fixes incorrect autocorrect for `Rails/RedirectBackOrTo` when additional options as double splat are used. ([@koic][])

--- a/spec/rubocop/cop/rails/redirect_back_or_to_spec.rb
+++ b/spec/rubocop/cop/rails/redirect_back_or_to_spec.rb
@@ -24,6 +24,17 @@ RSpec.describe RuboCop::Cop::Rails::RedirectBackOrTo, :config do
       RUBY
     end
 
+    it 'registers an offense and corrects with additional options as double splat' do
+      expect_offense(<<~RUBY)
+        redirect_back(fallback_location: root_path, **options)
+        ^^^^^^^^^^^^^ Use `redirect_back_or_to` instead of `redirect_back` with `:fallback_location` keyword argument.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        redirect_back_or_to(root_path, **options)
+      RUBY
+    end
+
     it 'registers no offense when using redirect_back_or_to' do
       expect_no_offenses(<<~RUBY)
         redirect_back_or_to(root_path)


### PR DESCRIPTION
This PR fixes incorrect autocorrect for `Rails/RedirectBackOrTo` when additional options as double splat are used.

Fixes #1558.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
