### PR TITLE
[Fix #1557] Fix false positives for Rails/Presence with comparison and assignment operators

### DIFF
--- a/changelog/fix_false_positives_for_rails_presence_with_comparison_and_assignment_operators.md
+++ b/changelog/fix_false_positives_for_rails_presence_with_comparison_and_assignment_operators.md
@@ -1,0 +1,1 @@
+* [#1557](https://github.com/rubocop/rubocop-rails/issues/1557): Fix false positives for `Rails/Presence` with comparison and assignment operators. ([@davidenglishmusic][])

--- a/lib/rubocop/cop/rails/presence.rb
+++ b/lib/rubocop/cop/rails/presence.rb
@@ -53,6 +53,16 @@ module RuboCop
       #
       #   # good
       #   a.presence&.foo
+      #
+      #   # good
+      #   a.present? ? a[1] : nil
+      #
+      #   # good
+      #   a[:key] = value if a.present?
+      #
+      #   # good
+      #   a.present? ? a > 1 : nil
+      #   a <= 0 if a.present?
       class Presence < Base
         include RangeHelp
         extend AutoCorrector
@@ -130,7 +140,7 @@ module RuboCop
         end
 
         def ignore_chain_node?(node)
-          node.method?('[]') || node.arithmetic_operation?
+          node.method?('[]') || node.method?('[]=') || node.arithmetic_operation? || node.comparison_method?
         end
 
         def message(node, replacement)

--- a/spec/rubocop/cop/rails/presence_spec.rb
+++ b/spec/rubocop/cop/rails/presence_spec.rb
@@ -295,9 +295,27 @@ RSpec.describe RuboCop::Cop::Rails::Presence, :config do
       RUBY
     end
 
+    it 'does not register an offense when chained method is `[]=`' do
+      expect_no_offenses(<<~RUBY)
+        a[1] = 1 if a.present?
+      RUBY
+    end
+
     it 'does not register an offense when chained method is an arithmetic operation' do
       expect_no_offenses(<<~RUBY)
         a.present? ? a + 42 : nil
+      RUBY
+    end
+
+    it 'does not register an offense when using comparison operation in modifier if' do
+      expect_no_offenses(<<~RUBY)
+        a <= 0 if a.present?
+      RUBY
+    end
+
+    it 'does not register an offense when chained method is a comparison operation in ternary' do
+      expect_no_offenses(<<~RUBY)
+        a.present? ? a > 42 : nil
       RUBY
     end
 


### PR DESCRIPTION
This PR fixes false positives for `Rails/Presence` with comparison and assignment operators.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
