### PR TITLE
[Fix #1561] Fix incorrect autocorrect for `Rails/RedirectBackOrTo`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_rails_redirect_back_or_to_cop.md
+++ b/changelog/fix_incorrect_autocorrect_for_rails_redirect_back_or_to_cop.md
@@ -1,0 +1,1 @@
+* [#1561](https://github.com/rubocop/rubocop-rails/issues/1561): Fix incorrect autocorrect for `Rails/RedirectBackOrTo` when `fallback_location` argument is a hash and the call has no argument parentheses. ([@koic][])

--- a/lib/rubocop/cop/rails/redirect_back_or_to.rb
+++ b/lib/rubocop/cop/rails/redirect_back_or_to.rb
@@ -61,6 +61,8 @@ module RuboCop
             first_pair = hash_arg.pairs.find { |pair| pair != fallback_pair }
             corrector.insert_before(first_pair, "#{fallback_value.source}, ")
           end
+
+          wrap_with_parentheses(node, corrector) unless node.parenthesized?
         end
         # rubocop:enable Metrics/AbcSize
 
@@ -75,6 +77,11 @@ module RuboCop
           else
             remove_non_first_pair(corrector, fallback_pair, pairs[index - 1])
           end
+        end
+
+        def wrap_with_parentheses(node, corrector)
+          corrector.replace(node.loc.selector.end.join(node.first_argument.source_range.begin), '(')
+          corrector.insert_after(node, ')')
         end
 
         def remove_first_pair(corrector, fallback_pair, next_pair)

--- a/spec/rubocop/cop/rails/redirect_back_or_to_spec.rb
+++ b/spec/rubocop/cop/rails/redirect_back_or_to_spec.rb
@@ -35,6 +35,28 @@ RSpec.describe RuboCop::Cop::Rails::RedirectBackOrTo, :config do
       RUBY
     end
 
+    it 'registers an offense and corrects when `fallback_location` arg is a hash and the call has no arg parentheses' do
+      expect_offense(<<~RUBY)
+        redirect_back fallback_location: {action: 'index'}
+        ^^^^^^^^^^^^^ Use `redirect_back_or_to` instead of `redirect_back` with `:fallback_location` keyword argument.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        redirect_back_or_to({action: 'index'})
+      RUBY
+    end
+
+    it 'registers an offense and corrects when `fallback_location` arg is a hash and the call uses arg parentheses' do
+      expect_offense(<<~RUBY)
+        redirect_back(fallback_location: {action: 'index'})
+        ^^^^^^^^^^^^^ Use `redirect_back_or_to` instead of `redirect_back` with `:fallback_location` keyword argument.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        redirect_back_or_to({action: 'index'})
+      RUBY
+    end
+
     it 'registers no offense when using redirect_back_or_to' do
       expect_no_offenses(<<~RUBY)
         redirect_back_or_to(root_path)


### PR DESCRIPTION
This PR fixes incorrect autocorrect for `Rails/RedirectBackOrTo` when `fallback_location` argument is a hash and the call has no argument parentheses.

Fixes #1561.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
