### PR TITLE
Remove unnecessary fallback code for `requires_gem`

### DIFF
--- a/lib/rubocop/cop/mixin/target_rails_version.rb
+++ b/lib/rubocop/cop/mixin/target_rails_version.rb
@@ -12,29 +12,19 @@ module RuboCop
       TARGET_GEM_NAME = 'railties' # :nodoc:
 
       def minimum_target_rails_version(version)
-        if respond_to?(:requires_gem)
-          case version
-          when Integer, Float then requires_gem(TARGET_GEM_NAME, ">= #{version}")
-          when String then requires_gem(TARGET_GEM_NAME, version)
-          end
-        else
-          # Fallback path for previous versions of RuboCop which don't support the `requires_gem` API yet.
-          @minimum_target_rails_version = version
+        case version
+        when Integer, Float then requires_gem(TARGET_GEM_NAME, ">= #{version}")
+        when String then requires_gem(TARGET_GEM_NAME, version)
         end
       end
 
       def support_target_rails_version?(version)
-        if respond_to?(:requires_gem)
-          return false unless gem_requirements
+        return false unless gem_requirements
 
-          gem_requirement = gem_requirements[TARGET_GEM_NAME]
-          return true unless gem_requirement # If we have no requirement, then we support all versions
+        gem_requirement = gem_requirements[TARGET_GEM_NAME]
+        return true unless gem_requirement # If we have no requirement, then we support all versions
 
-          gem_requirement.satisfied_by?(Gem::Version.new(version))
-        else
-          # Fallback path for previous versions of RuboCop which don't support the `requires_gem` API yet.
-          @minimum_target_rails_version <= version
-        end
+        gem_requirement.satisfied_by?(Gem::Version.new(version))
       end
     end
   end


### PR DESCRIPTION
This is not a significant change, just minor refactoring.

`requires_gem` was added in rubocop 1.63.0.

- https://github.com/rubocop/rubocop/pull/12186

rubocop-rails currently requires rubocop 1.75.0 or higher.

https://github.com/rubocop/rubocop-rails/blob/cf897f31ab99619faab56acece98c3552531d705/rubocop-rails.gemspec#L39

Therefore, the code to maintain compatibility with rubocop versions below 1.63.0 is likely no longer necessary.