### PR TITLE
[Fix #1565] Make `Rails/Presence` allow index access methods

### DIFF
--- a/changelog/change_make_rails_presence_allow_index_access_methods.md
+++ b/changelog/change_make_rails_presence_allow_index_access_methods.md
@@ -1,0 +1,1 @@
+* [#1565](https://github.com/rubocop/rubocop-rails/issues/1565): Make `Rails/Presence` allow index access methods. ([@koic][])

--- a/lib/rubocop/cop/rails/presence.rb
+++ b/lib/rubocop/cop/rails/presence.rb
@@ -68,6 +68,7 @@ module RuboCop
         extend AutoCorrector
 
         MSG = 'Use `%<prefer>s` instead of `%<current>s`.'
+        INDEX_ACCESS_METHODS = %i[[] []=].freeze
 
         def_node_matcher :redundant_receiver_and_other, <<~PATTERN
           {
@@ -140,7 +141,7 @@ module RuboCop
         end
 
         def ignore_chain_node?(node)
-          node.method?('[]') || node.method?('[]=') || node.arithmetic_operation? || node.comparison_method?
+          index_access_method?(node) || node.assignment? || node.arithmetic_operation? || node.comparison_method?
         end
 
         def message(node, replacement)
@@ -189,6 +190,10 @@ module RuboCop
           replaced = "#{receiver.source}.presence&.#{chain.method_name}"
           replaced += "(#{chain.arguments.map(&:source).join(', ')})" if chain.arguments?
           left_sibling ? "(#{replaced})" : replaced
+        end
+
+        def index_access_method?(node)
+          INDEX_ACCESS_METHODS.include?(node.method_name)
         end
       end
     end

--- a/spec/rubocop/cop/rails/presence_spec.rb
+++ b/spec/rubocop/cop/rails/presence_spec.rb
@@ -301,6 +301,12 @@ RSpec.describe RuboCop::Cop::Rails::Presence, :config do
       RUBY
     end
 
+    it 'does not register an offense when chained method is attribute assignment' do
+      expect_no_offenses(<<~RUBY)
+        a.attribute = 42 if a.present?
+      RUBY
+    end
+
     it 'does not register an offense when chained method is an arithmetic operation' do
       expect_no_offenses(<<~RUBY)
         a.present? ? a + 42 : nil


### PR DESCRIPTION
This PR makes `Rails/Presence` allow index access methods.

Fixes #1565.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
