### PR TITLE
[Fix #1569] Fix an error in `Rails/SelectMap`

### DIFF
--- a/changelog/fix_an_error_for_rails_select_map_cop.md
+++ b/changelog/fix_an_error_for_rails_select_map_cop.md
@@ -1,0 +1,1 @@
+* [#1569](https://github.com/rubocop/rubocop-rails/issues/1569): Fix an error in `Rails/SelectMap` when multiple `select` calls are present before `map`. ([@koic][])

--- a/lib/rubocop/cop/rails/select_map.rb
+++ b/lib/rubocop/cop/rails/select_map.rb
@@ -45,11 +45,15 @@ module RuboCop
         private
 
         def find_select_node(node, column_name)
-          node.descendants.detect do |select_candidate|
+          select_method_nodes = node.descendants.select do |select_candidate|
             next if !select_candidate.call_type? || !select_candidate.method?(:select)
 
             match_column_name?(select_candidate, column_name)
           end
+
+          return unless select_method_nodes.one?
+
+          select_method_nodes.first
         end
 
         # rubocop:disable Metrics/AbcSize

--- a/spec/rubocop/cop/rails/select_map_spec.rb
+++ b/spec/rubocop/cop/rails/select_map_spec.rb
@@ -114,6 +114,12 @@ RSpec.describe RuboCop::Cop::Rails::SelectMap, :config do
     RUBY
   end
 
+  it 'does not register an offense when multiple `select` calls are present before `map`' do
+    expect_no_offenses(<<~RUBY)
+      (Foo.select(:column_name) + Bar.select(:column_name)).map(&:column_name)
+    RUBY
+  end
+
   it 'does not register an offense when using `pluck(:column_name)`' do
     expect_no_offenses(<<~RUBY)
       Model.pluck(:column_name)


### PR DESCRIPTION
This PR fixes an error in `Rails/SelectMap` when multiple `select` calls are present before `map`.

Fixes #1569.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
