### PR TITLE
Add more detection patterns on `Rails/ResponseParsedBody`

### DIFF
--- a/changelog/change_add_more_detection_patterns_on.md
+++ b/changelog/change_add_more_detection_patterns_on.md
@@ -1,0 +1,1 @@
+* [#1571](https://github.com/rubocop/rubocop-rails/pull/1571): Add more detection patterns on `Rails/ResponseParsedBody`. ([@r7kamura][])

--- a/spec/rubocop/cop/rails/response_parsed_body_spec.rb
+++ b/spec/rubocop/cop/rails/response_parsed_body_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe RuboCop::Cop::Rails::ResponseParsedBody, :config do
     it 'registers offense' do
       expect_offense(<<~RUBY)
         expect(JSON.parse(response.body)).to eq('foo' => 'bar')
-               ^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `response.parsed_body` to `JSON.parse(response.body)`.
+               ^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `response.parsed_body`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -34,7 +34,7 @@ RSpec.describe RuboCop::Cop::Rails::ResponseParsedBody, :config do
     it 'registers offense' do
       expect_offense(<<~RUBY)
         expect(::JSON.parse(response.body)).to eq('foo' => 'bar')
-               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `response.parsed_body` to `JSON.parse(response.body)`.
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `response.parsed_body`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -43,19 +43,19 @@ RSpec.describe RuboCop::Cop::Rails::ResponseParsedBody, :config do
     end
   end
 
-  context 'when `Nokogiri::HTML.parse(response.body)` is used on Rails 7.0', :rails70 do
+  context 'when `Nokogiri::HTML(response.body)` is used on Rails 7.0', :rails70 do
     it 'registers no offense' do
       expect_no_offenses(<<~RUBY)
-        Nokogiri::HTML.parse(response.body)
+        Nokogiri::HTML(response.body)
       RUBY
     end
   end
 
-  context 'when `Nokogiri::HTML.parse(response.body)` is used on Rails 7.1', :rails71 do
+  context 'when `Nokogiri::HTML(response.body)`', :rails71 do
     it 'registers offense' do
       expect_offense(<<~RUBY)
-        Nokogiri::HTML.parse(response.body)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `response.parsed_body` to `Nokogiri::HTML.parse(response.body)`.
+        Nokogiri::HTML(response.body)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `response.parsed_body`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -64,11 +64,102 @@ RSpec.describe RuboCop::Cop::Rails::ResponseParsedBody, :config do
     end
   end
 
-  context 'when `Nokogiri::HTML5.parse(response.body)` is used on Rails 7.1', :rails71 do
+  context 'when `Nokogiri::HTML4(response.body)`', :rails71 do
+    it 'registers offense' do
+      expect_offense(<<~RUBY)
+        Nokogiri::HTML4(response.body)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `response.parsed_body`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        response.parsed_body
+      RUBY
+    end
+  end
+
+  context 'when `Nokogiri::HTML5(response.body)`', :rails71 do
+    it 'registers offense' do
+      expect_offense(<<~RUBY)
+        Nokogiri::HTML5(response.body)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `response.parsed_body`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        response.parsed_body
+      RUBY
+    end
+  end
+
+  context 'when `Nokogiri::HTML.parse(response.body)`', :rails71 do
+    it 'registers offense' do
+      expect_offense(<<~RUBY)
+        Nokogiri::HTML.parse(response.body)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `response.parsed_body`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        response.parsed_body
+      RUBY
+    end
+  end
+
+  context 'when `Nokogiri::HTML4.parse(response.body)`', :rails71 do
+    it 'registers offense' do
+      expect_offense(<<~RUBY)
+        Nokogiri::HTML4.parse(response.body)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `response.parsed_body`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        response.parsed_body
+      RUBY
+    end
+  end
+
+  context 'when `Nokogiri::HTML5.parse(response.body)`', :rails71 do
     it 'registers offense' do
       expect_offense(<<~RUBY)
         Nokogiri::HTML5.parse(response.body)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `response.parsed_body` to `Nokogiri::HTML5.parse(response.body)`.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `response.parsed_body`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        response.parsed_body
+      RUBY
+    end
+  end
+
+  context 'when `Nokogiri::HTML::Document.parse(response.body)`', :rails71 do
+    it 'registers offense' do
+      expect_offense(<<~RUBY)
+        Nokogiri::HTML::Document.parse(response.body)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `response.parsed_body`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        response.parsed_body
+      RUBY
+    end
+  end
+
+  context 'when `Nokogiri::HTML4::Document.parse(response.body)`', :rails71 do
+    it 'registers offense' do
+      expect_offense(<<~RUBY)
+        Nokogiri::HTML4::Document.parse(response.body)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `response.parsed_body`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        response.parsed_body
+      RUBY
+    end
+  end
+
+  context 'when `Nokogiri::HTML5::Document.parse(response.body)`', :rails71 do
+    it 'registers offense' do
+      expect_offense(<<~RUBY)
+        Nokogiri::HTML5::Document.parse(response.body)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `response.parsed_body`.
       RUBY
 
       expect_correction(<<~RUBY)


### PR DESCRIPTION
Added detection patterns to correctly detect some of Nokogiri's aliases as well.

|Code|Before|After|
|---|---|---|
|`JSON.parse(response.body)`|bad|bad|
|`Nokogiri::HTML(response.body)`|good|bad|
|`Nokogiri::HTML4(response.body)`|good|bad|
|`Nokogiri::HTML5(response.body)`|good|bad|
|`Nokogiri::HTML.parse(response.body)`|bad|bad|
|`Nokogiri::HTML4.parse(response.body)`|good|bad|
|`Nokogiri::HTML5.parse(response.body)`|bad|bad|
|`Nokogiri::HTML::Document.parse(response.body)`|good|bad|
|`Nokogiri::HTML4::Document.parse(response.body)`|good|bad|
|`Nokogiri::HTML5::Document.parse(response.body)`|good|bad|

Note: The originally supported `Nokogiri::HTML` corresponds to `Nokogiri::HTML4`, so both HTML4 and HTML5 were originally detected. See docs about more details:

- https://nokogiri.org/rdoc/index.html

---

Additionally, I simplified the offense message. This was done out of concern that optimizing the message might complicate the code, given the increased scope of this implementation.

```
# Before
Prefer `response.parsed_body` to `Nokogiri::HTML.parse(response.body)`.

# After
Prefer `response.parsed_body`.
```