### PR TITLE
Fix an error for `Rails/SelectMap`

### DIFF
--- a/changelog/fix_an_error_for_rails_select_map.md
+++ b/changelog/fix_an_error_for_rails_select_map.md
@@ -1,0 +1,1 @@
+* [#1473](https://github.com/rubocop/rubocop-rails/pull/1473): Fix an error for `Rails/SelectMap` when `select(:column_name).map(&:column_name)` with parentheses. ([@koic][])

--- a/lib/rubocop/cop/rails/select_map.rb
+++ b/lib/rubocop/cop/rails/select_map.rb
@@ -58,9 +58,13 @@ module RuboCop
 
         # rubocop:disable Metrics/AbcSize
         def autocorrect(corrector, select_node, node, preferred_method)
-          corrector.remove(select_node.parent.loc.dot)
-          corrector.remove(select_node.loc.selector.begin.join(select_node.source_range.end))
-          corrector.replace(node.loc.selector.begin.join(node.source_range.end), preferred_method)
+          if (parent = select_node.parent).loc?(:dot)
+            corrector.remove(parent.loc.dot)
+            corrector.remove(select_node.loc.selector.begin.join(select_node.source_range.end))
+            corrector.replace(node.loc.selector.begin.join(node.source_range.end), preferred_method)
+          else
+            corrector.replace(node, "#{select_node.receiver.source}.#{preferred_method}")
+          end
         end
         # rubocop:enable Metrics/AbcSize
 

--- a/spec/rubocop/cop/rails/select_map_spec.rb
+++ b/spec/rubocop/cop/rails/select_map_spec.rb
@@ -12,6 +12,17 @@ RSpec.describe RuboCop::Cop::Rails::SelectMap, :config do
     RUBY
   end
 
+  it 'registers an offense when using `select(:column_name).map(&:column_name)` with parentheses' do
+    expect_offense(<<~RUBY)
+      (Model.select(:column_name)).map(&:column_name)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `pluck(:column_name)` instead of `select` with `map`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Model.pluck(:column_name)
+    RUBY
+  end
+
   it "registers an offense when using `select('column_name').map(&:column_name)`" do
     expect_offense(<<~RUBY)
       Model.select('column_name').map(&:column_name)


### PR DESCRIPTION
This PR fixes the following error for `Rails/SelectMap` when `select(:column_name).map(&:column_name)` with parentheses.

```console
$ echo '(Model.select(:column_name)).map(&:column_name)' | be rubocop -s example.rb --only Rails/SelectMap -d
(snip)

An error occurred while Rails/SelectMap cop was inspecting /Users/koic/src/github.com/rubocop/rubocop-rails/example.rb:1:0.
/Users/koic/src/github.com/rubocop/rubocop-rails/lib/rubocop/cop/rails/select_map.rb:61:
in 'RuboCop::Cop::Rails::SelectMap#autocorrect': undefined method 'dot' for an instance of Parser::Source::Map::Collection (NoMethodError)

          corrector.remove(select_node.parent.loc.dot)
                                                 ^^^^
        from /Users/koic/src/github.com/rubocop/rubocop-rails/lib/rubocop/cop/rails/select_map.rb:40:
             in 'block in RuboCop::Cop::Rails::SelectMap#on_send'
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
