### PR TITLE
fix(presence): ignore numeric transformations

### DIFF
--- a/changelog/fix_fix_presence_ignore_numeric.md
+++ b/changelog/fix_fix_presence_ignore_numeric.md
@@ -1,0 +1,1 @@
+* [#1576](https://github.com/rubocop/rubocop-rails/pull/1576): Fix(presence): ignore numeric transformations. ([@markokajzer][])

--- a/lib/rubocop/cop/rails/presence.rb
+++ b/lib/rubocop/cop/rails/presence.rb
@@ -69,6 +69,7 @@ module RuboCop
 
         MSG = 'Use `%<prefer>s` instead of `%<current>s`.'
         INDEX_ACCESS_METHODS = %i[[] []=].freeze
+        NUMERIC_CONVERSION_METHODS = %i[to_i to_f].freeze
 
         def_node_matcher :redundant_receiver_and_other, <<~PATTERN
           {
@@ -141,7 +142,11 @@ module RuboCop
         end
 
         def ignore_chain_node?(node)
-          index_access_method?(node) || node.assignment? || node.arithmetic_operation? || node.comparison_method?
+          index_access_method?(node) ||
+            numeric_conversion_method?(node) ||
+            node.assignment? ||
+            node.arithmetic_operation? ||
+            node.comparison_method?
         end
 
         def message(node, replacement)
@@ -194,6 +199,10 @@ module RuboCop
 
         def index_access_method?(node)
           INDEX_ACCESS_METHODS.include?(node.method_name)
+        end
+
+        def numeric_conversion_method?(node)
+          NUMERIC_CONVERSION_METHODS.include?(node.method_name)
         end
       end
     end

--- a/spec/rubocop/cop/rails/presence_spec.rb
+++ b/spec/rubocop/cop/rails/presence_spec.rb
@@ -301,6 +301,12 @@ RSpec.describe RuboCop::Cop::Rails::Presence, :config do
       RUBY
     end
 
+    it 'does not register an offense when chained method is `to_i`' do
+      expect_no_offenses(<<~RUBY)
+        a.to_i if a.present?
+      RUBY
+    end
+
     it 'does not register an offense when chained method is attribute assignment' do
       expect_no_offenses(<<~RUBY)
         a.attribute = 42 if a.present?


### PR DESCRIPTION
Since `nil&.to_i` is `0` instead of `nil`, these method calls should probably be ignored. otherwise it changes the semantics and the autofix potentially introduces a bug (which is what happened to me lol)

imagine the following scenario

```
# before
@user_id = params[:user_id].present? ? params[:user_id].to_i : nil

# after
@user_id = params[:user_id].presence&.to_i
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
