### PR TITLE
Don't allow `local` when used in equality comparison in `Rails/UnknownEnv` 

### DIFF
--- a/changelog/fix_unknown_env_local_comparison.md
+++ b/changelog/fix_unknown_env_local_comparison.md
@@ -1,0 +1,1 @@
+* [#1582](https://github.com/rubocop/rubocop-rails/pull/1582): Fix a false negative where `local` was incorrectly treated as a known environment name when using `==` comparison in `Rails/UnknownEnv`. ([@lovro-bikic][])

--- a/lib/rubocop/cop/rails/unknown_env.rb
+++ b/lib/rubocop/cop/rails/unknown_env.rb
@@ -51,10 +51,6 @@ module RuboCop
 
         private
 
-        def collect_variable_like_names(_scope)
-          environments
-        end
-
         def message(name)
           name = name.to_s.chomp('?')
 
@@ -78,19 +74,21 @@ module RuboCop
 
         def unknown_env_predicate?(name)
           name = name.to_s
-          name.end_with?('?') && !environments.include?(name[0..-2])
+          name.end_with?('?') && !environments(with_local: true).include?(name[0..-2])
         end
 
         def unknown_env_name?(name)
           !environments.include?(name)
         end
 
-        def environments
-          @environments ||= begin
-            environments = cop_config['Environments'].dup || []
-            environments << 'local' if target_rails_version >= 7.1
-            environments
-          end
+        def environments(with_local: false)
+          environments = cop_config['Environments'] || []
+          environments += ['local'] if with_local && supports_local?
+          environments
+        end
+
+        def supports_local?
+          target_rails_version >= 7.1
         end
       end
     end

--- a/spec/rubocop/cop/rails/unknown_env_spec.rb
+++ b/spec/rubocop/cop/rails/unknown_env_spec.rb
@@ -85,17 +85,22 @@ RSpec.describe RuboCop::Cop::Rails::UnknownEnv, :config do
   end
 
   context 'when Rails 7.1 or newer', :rails71 do
+    it 'registers an offense for environment `local` with `==` operator' do
+      expect_offense(<<~RUBY)
+        Rails.env == 'local'
+                     ^^^^^^^ Unknown environment `local`.
+      RUBY
+    end
+
     it 'accepts local as an environment name' do
       expect_no_offenses(<<~RUBY)
         Rails.env.local?
-        Rails.env == 'local'
       RUBY
     end
 
     it 'does not mutate the cop config' do
       expect_no_offenses(<<~RUBY)
         Rails.env.local?
-        Rails.env == 'local'
       RUBY
 
       expect(cop_config['Environments'].include?('local')).to be(false)
@@ -111,7 +116,6 @@ RSpec.describe RuboCop::Cop::Rails::UnknownEnv, :config do
       it 'accepts local as an environment name' do
         expect_no_offenses(<<~RUBY)
           Rails.env.local?
-          Rails.env == 'local'
         RUBY
       end
     end


### PR DESCRIPTION
Currently, `Rails/UnknownEnv` will permit `local` environment as both a predicate and in `==` comparison:
```ruby
# assuming that:
Rails.env
# => "development"

Rails.env.local?
# => true

Rails.env == 'local'
# => false
```

Predicate `local?` should be accepted by the cop, but `== 'local'` shouldn't because `==` operator compares with the current environment _name_, which can never be `local`.

This PR changes the cop so that `Rails.env == 'local'` is registered as an offense ([this GitHub search](https://github.com/search?q=%2FRails%5C.env%20%3D%3D%20(%27local%27%7C%22local%22)%2F%20lang%3Aruby&type=code) shows there are some would-be offenses).

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
