### PR TITLE
Make `Rails/StrongParametersExpect` aware of `params[:key]`

### DIFF
--- a/changelog/change_enhance_rails_strong_parameters_expect.md
+++ b/changelog/change_enhance_rails_strong_parameters_expect.md
@@ -1,0 +1,1 @@
+* [#1583](https://github.com/rubocop/rubocop-rails/pull/1583): Extend `Rails/StrongParametersExpect` to detect `params[:key]` in method calls and raising finder methods. ([@koic][])

--- a/lib/rubocop/cop/rails/strong_parameters_expect.rb
+++ b/lib/rubocop/cop/rails/strong_parameters_expect.rb
@@ -5,6 +5,15 @@ module RuboCop
     module Rails
       # Enforces the use of `ActionController::Parameters#expect` as a method for strong parameter handling.
       #
+      # In the following cases, `params[:key]` is treated as a key that is expected to be passed from the HTTP client,
+      # and the cop detects it using the `expect` method.
+      #
+      # - Method calls on `params[:key]` without comparison methods
+      # - Passing `params[:key]` as an argument to finder methods that raise on missing records
+      # - Strong parameter methods using `require` or `permit`
+      #
+      # Other cases are not detected, as they are cases where `params[:key]` may not be passed from the HTTP client.
+      #
       # @safety
       #   This cop's autocorrection is considered unsafe because there are cases where the HTTP status may change
       #   from 500 to 400 when handling invalid parameters. This change, however, reflects an intentional
@@ -12,6 +21,24 @@ module RuboCop
       #   strong parameter conventions.
       #
       # @example
+      #
+      #   # bad
+      #   params[:key].do_something
+      #
+      #   # good
+      #   params.expect(:key).do_something
+      #
+      #   # bad
+      #   Model.find(params[:id])
+      #
+      #   # good
+      #   Model.find(params.expect(:id))
+      #
+      #   # bad
+      #   Model.find_by!(key: params[:key])
+      #
+      #   # good
+      #   Model.find_by!(key: params.expect(:key))
       #
       #   # bad
       #   params.require(:user).permit(:name, :age)
@@ -25,9 +52,15 @@ module RuboCop
         extend TargetRailsVersion
 
         MSG = 'Use `%<prefer>s` instead.'
-        RESTRICT_ON_SEND = %i[require permit].freeze
+        RESTRICT_ON_SEND = %i[[] require permit].freeze
+        PRESENCE_CHECK_METHODS = %i[nil? blank? present?].freeze
+        RAISING_FINDER_METHODS = %i[find find_by! find_sole_by].freeze
 
         minimum_target_rails_version 8.0
+
+        def_node_matcher :params_bracket_access, <<~PATTERN
+          (send (send nil? :params) :[] $_)
+        PATTERN
 
         def_node_matcher :params_require_permit, <<~PATTERN
           $(call
@@ -45,6 +78,11 @@ module RuboCop
         # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
         def on_send(node)
           return if part_of_ignored_node?(node)
+
+          if (params_key = params_bracket_access(node))
+            register_bracket_access_offense(node, params_key)
+            return
+          end
 
           if (permit_method, require_method = params_require_permit(node))
             range = offense_range(require_method, node)
@@ -73,6 +111,38 @@ module RuboCop
         alias on_csend on_send
 
         private
+
+        def register_bracket_access_offense(node, params_key)
+          return unless offensive_bracket_access?(node)
+
+          range = offense_range(node, node)
+          prefer = "expect(#{params_key.source})"
+
+          add_offense(range, message: format(MSG, prefer: prefer)) do |corrector|
+            corrector.replace(range, ".#{prefer}")
+          end
+        end
+
+        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        def offensive_bracket_access?(node)
+          return false unless (parent = node.parent)
+          return false if parent.or_type?
+          return true if parent.each_ancestor(:call).any? { |node| raising_finder_method?(node) }
+          return false unless parent.call_type?
+
+          if parent.receiver == node
+            return false if parent.comparison_method?
+
+            !parent.method?(:[]) && !PRESENCE_CHECK_METHODS.include?(parent.method_name)
+          else
+            raising_finder_method?(parent)
+          end
+        end
+        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+
+        def raising_finder_method?(node)
+          RAISING_FINDER_METHODS.include?(node.method_name)
+        end
 
         def offense_range(method_node, node)
           method_node.loc.selector.join(node.source_range.end)

--- a/spec/rubocop/cop/rails/strong_parameters_expect_spec.rb
+++ b/spec/rubocop/cop/rails/strong_parameters_expect_spec.rb
@@ -2,6 +2,181 @@
 
 RSpec.describe RuboCop::Cop::Rails::StrongParametersExpect, :config do
   context 'Rails >= 8.0', :rails80 do
+    it 'registers an offense when using `params[:key]` with method call' do
+      expect_offense(<<~RUBY)
+        params[:key].do_something
+              ^^^^^^ Use `expect(:key)` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        params.expect(:key).do_something
+      RUBY
+    end
+
+    it 'does not register an offense when using `params[:key]`' do
+      expect_no_offenses(<<~RUBY)
+        params[:key]
+      RUBY
+    end
+
+    it 'does not register an offense when using `params[:key].nil?`' do
+      expect_no_offenses(<<~RUBY)
+        params[:key].nil?
+      RUBY
+    end
+
+    it "does not register an offense when using `params[:key] == 'value'`" do
+      expect_no_offenses(<<~RUBY)
+        params[:key] == 'value'
+      RUBY
+    end
+
+    it 'does not register an offense when using `params[:key].blank?`' do
+      expect_no_offenses(<<~RUBY)
+        params[:key].blank?
+      RUBY
+    end
+
+    it 'does not register an offense when using `params[:key].present?`' do
+      expect_no_offenses(<<~RUBY)
+        params[:key].present?
+      RUBY
+    end
+
+    it 'registers an offense when using `Model.find(params[:id])`' do
+      expect_offense(<<~RUBY)
+        Model.find(params[:id])
+                         ^^^^^ Use `expect(:id)` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Model.find(params.expect(:id))
+      RUBY
+    end
+
+    it 'registers an offense when using `Model&.find(params[:id])`' do
+      expect_offense(<<~RUBY)
+        Model&.find(params[:id])
+                          ^^^^^ Use `expect(:id)` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Model&.find(params.expect(:id))
+      RUBY
+    end
+
+    it 'does not register an offense when using `Model.find(params[:id]) || DEFAULT_VALUE`' do
+      expect_no_offenses(<<~RUBY)
+        Model.find(params[:id] || DEFAULT_VALUE)
+      RUBY
+    end
+
+    it 'does not register an offense when using `Model.find_by(key: params[:key])`' do
+      expect_no_offenses(<<~RUBY)
+        Model.find_by(key: params[:key])
+      RUBY
+    end
+
+    it 'registers an offense when using `Model.find_by!(key: params[:key])`' do
+      expect_offense(<<~RUBY)
+        Model.find_by!(key: params[:key])
+                                  ^^^^^^ Use `expect(:key)` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Model.find_by!(key: params.expect(:key))
+      RUBY
+    end
+
+    it 'does not register an offense when using `Model.find_or_initialize_by(key: params[:key])`' do
+      expect_no_offenses(<<~RUBY)
+        Model.find_or_initialize_by(key: params[:key])
+      RUBY
+    end
+
+    it 'does not register an offense when using `Model&.find_or_initialize_by(key: params[:key])`' do
+      expect_no_offenses(<<~RUBY)
+        Model&.find_or_initialize_by(key: params[:key])
+      RUBY
+    end
+
+    it 'does not register an offense when using `Model.find_or_create_by(key: params[:key])`' do
+      expect_no_offenses(<<~RUBY)
+        Model.find_or_create_by(key: params[:key])
+      RUBY
+    end
+
+    it 'does not register an offense when using `Model.find_or_create_by!(key: params[:key])`' do
+      expect_no_offenses(<<~RUBY)
+        Model.find_or_create_by!(key: params[:key])
+      RUBY
+    end
+
+    it 'registers an offense when using `Model.find_sole_by(key: params[:key])`' do
+      expect_offense(<<~RUBY)
+        Model.find_sole_by(key: params[:key])
+                                      ^^^^^^ Use `expect(:key)` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Model.find_sole_by(key: params.expect(:key))
+      RUBY
+    end
+
+    it 'does not register an offense when using `Model.find(non_params[:key])`' do
+      expect_no_offenses(<<~RUBY)
+        Model.find(non_params[:key])
+      RUBY
+    end
+
+    it 'does not register an offense when using `Model.findxxx(params[:key])`' do
+      expect_no_offenses(<<~RUBY)
+        Model.findxxx(params[:key])
+      RUBY
+    end
+
+    it 'does not register an offense when using methods that do not start with `find_` such as `Model.where' do
+      expect_no_offenses(<<~RUBY)
+        Model.where(key: params[:key])
+      RUBY
+    end
+
+    it 'does not register an offense when using `Model.delete(params[:id])`' do
+      expect_no_offenses(<<~RUBY)
+        Model.delete(params[:id])
+      RUBY
+    end
+
+    it 'does not register an offense when using `Model.destroy(params[:id])`' do
+      expect_no_offenses(<<~RUBY)
+        Model.destroy(params[:id])
+      RUBY
+    end
+
+    it 'does not register an offense when using `Model.delete_by(key: params[:key])`' do
+      expect_no_offenses(<<~RUBY)
+        Model.delete_by(key: params[:key])
+      RUBY
+    end
+
+    it 'does not register an offense when using `Model.destroy_by(params[:key])`' do
+      expect_no_offenses(<<~RUBY)
+        Model.destroy_by(key: params[:key])
+      RUBY
+    end
+
+    it 'does not register an offense when using `Model.delete_custom_method(params[:key])`' do
+      expect_no_offenses(<<~RUBY)
+        Model.delete_custom_method(params[:key])
+      RUBY
+    end
+
+    it 'does not register an offense when using `Model.destroy_custom_method(params[:key])`' do
+      expect_no_offenses(<<~RUBY)
+        Model.destroy_custom_method(params[:key])
+      RUBY
+    end
+
     it 'registers an offense when using `params.require(:user).permit(:name, :age)`' do
       expect_offense(<<~RUBY)
         params.require(:user).permit(:name, :age)


### PR DESCRIPTION
This PR makes `Rails/StrongParametersExpect` aware of `params[:key]` for the following cases, `params[:key]` is treated as a key that is expected to be passed from the HTTP client, and the cop detects it using the `expect` method.

- Method calls on `params[:key]` without comparison methods
- Passing `params[:key]` as an argument to finder methods that raise on missing records
- Strong parameter methods using `require` or `permit`

Other cases are not detected, as they are cases where `params[:key]` may not be passed from the HTTP client.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
