### PR TITLE
Add support for `case` statements to `Rails/UnknownEnv`

### DIFF
--- a/changelog/change_rails_unknown_env_support_for_case.md
+++ b/changelog/change_rails_unknown_env_support_for_case.md
@@ -1,0 +1,1 @@
+* [#1584](https://github.com/rubocop/rubocop-rails/pull/1584): Add support for `case` statements to `Rails/UnknownEnv`. ([@lovro-bikic][])

--- a/spec/rubocop/cop/rails/unknown_env_spec.rb
+++ b/spec/rubocop/cop/rails/unknown_env_spec.rb
@@ -43,6 +43,47 @@ RSpec.describe RuboCop::Cop::Rails::UnknownEnv, :config do
           ^^^^^^^ Unknown environment `local`.
         RUBY
       end
+
+      it 'registers an offense when case condition is an unknown environment name' do
+        expect_offense(<<~RUBY)
+          case Rails.env
+          when 'proudction'
+               ^^^^^^^^^^^^ Unknown environment `proudction`. Did you mean `production`?
+            something
+          end
+        RUBY
+      end
+
+      it 'registers an offense for `case` when there are multiple conditions in one `when`' do
+        expect_offense(<<~RUBY)
+          case Rails.env
+          when 'development', 'proudction'
+                              ^^^^^^^^^^^^ Unknown environment `proudction`. Did you mean `production`?
+            something
+          end
+        RUBY
+      end
+
+      it 'accepts when case condition is not a string' do
+        expect_no_offenses(<<~RUBY)
+          case Rails.env
+          when proudction
+            something
+          end
+        RUBY
+      end
+
+      context 'when Rails 7.1 or newer', :rails71 do
+        it 'registers an offense when case condition is string "local"' do
+          expect_offense(<<~RUBY)
+            case Rails.env
+            when 'local'
+                 ^^^^^^^ Unknown environment `local`.
+              something
+            end
+          RUBY
+        end
+      end
     end
   else
     context 'when DidYouMean is not available' do


### PR DESCRIPTION
This PR adds support for recognizing unknown environments in `case` statements with the `Rails/UnknownEnv` cop, e.g.:
```ruby
case Rails.env
when 'development'
  foo
when 'proudction' # typo!!
  bar
else
  baz
end
```

At the time of writing, there are [1.2k results on GitHub search for `case Rails.env`](https://github.com/search?q=%2Fcase%20Rails%5C.env%24%2F%20lang%3Aruby&type=code).

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
