### PR TITLE
Don't add unnecessary parentheses in Rails/Presence

### DIFF
--- a/changelog/fix_rails_presence_parentheses.md
+++ b/changelog/fix_rails_presence_parentheses.md
@@ -1,0 +1,1 @@
+* [#1586](https://github.com/rubocop/rubocop-rails/pull/1586): Don't add unnecessary parentheses in `Rails/Presence`. ([@eugeneius][])


### PR DESCRIPTION
Previously the correction was wrapped in parentheses when the original node had a left sibling, but `if` nodes almost always have one, so in practice the parentheses were often added unnecessarily.

There are only two cases where parentheses are actually needed: when the `if` node is an argument to a method call without its own parentheses, or when it's the child of an `and` node.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/