### PR TITLE
Don't autocorrect operator methods in Rails/Presence

### DIFF
--- a/changelog/fix_presence_operator_methods.md
+++ b/changelog/fix_presence_operator_methods.md
@@ -1,0 +1,1 @@
+* [#1587](https://github.com/rubocop/rubocop-rails/pull/1587): Fix false positives for `Rails/Presence` with operator methods like `<<`, `=~`, and others. ([@eugeneius][])

--- a/lib/rubocop/cop/rails/presence.rb
+++ b/lib/rubocop/cop/rails/presence.rb
@@ -54,6 +54,7 @@ module RuboCop
       #   # good
       #   a.presence&.foo
       #
+      # @example
       #   # good
       #   a.present? ? a[1] : nil
       #
@@ -62,13 +63,17 @@ module RuboCop
       #
       #   # good
       #   a.present? ? a > 1 : nil
+      #
+      #   # good
       #   a <= 0 if a.present?
+      #
+      #   # good
+      #   a << "bar" if a.present?
       class Presence < Base
         include RangeHelp
         extend AutoCorrector
 
         MSG = 'Use `%<prefer>s` instead of `%<current>s`.'
-        INDEX_ACCESS_METHODS = %i[[] []=].freeze
 
         def_node_matcher :redundant_receiver_and_other, <<~PATTERN
           {
@@ -141,7 +146,7 @@ module RuboCop
         end
 
         def ignore_chain_node?(node)
-          index_access_method?(node) || node.assignment? || node.arithmetic_operation? || node.comparison_method?
+          node.assignment? || node.operator_method?
         end
 
         def message(node, replacement)
@@ -190,10 +195,6 @@ module RuboCop
           replaced = "#{receiver.source}.presence&.#{chain.method_name}"
           replaced += "(#{chain.arguments.map(&:source).join(', ')})" if chain.arguments?
           left_sibling ? "(#{replaced})" : replaced
-        end
-
-        def index_access_method?(node)
-          INDEX_ACCESS_METHODS.include?(node.method_name)
         end
       end
     end

--- a/spec/rubocop/cop/rails/presence_spec.rb
+++ b/spec/rubocop/cop/rails/presence_spec.rb
@@ -325,6 +325,18 @@ RSpec.describe RuboCop::Cop::Rails::Presence, :config do
       RUBY
     end
 
+    it 'does not register an offense when chained method is `<<`' do
+      expect_no_offenses(<<~RUBY)
+        foo << "bar" if foo.present?
+      RUBY
+    end
+
+    it 'does not register an offense when chained method is `=~`' do
+      expect_no_offenses(<<~RUBY)
+        foo =~ /pattern/ if foo.present?
+      RUBY
+    end
+
     it 'does not register an offense when multiple methods are chained' do
       expect_no_offenses(<<~RUBY)
         a.present? ? a.foo.bar : nil


### PR DESCRIPTION
The cop was autocorrecting operator methods like `<<` and `=~` into the much uglier `foo.presence&.<<("bar")`. The `ignore_chain_node?` method checked `arithmetic_operation?` and `comparison_method?`, but operators like `<<`, `>>`, `|`, `&`, `^`, `<=>`, `=~`, `!~`, and unary operators fell through the cracks.

Replace those checks with `operator_method?`, which covers all operator methods. This also subsumes the `index_access_method?` check for `[]` and `[]=`, so that helper and its constant can be removed.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/