### PR TITLE
Fix Rails/Presence false positive when receiver is used in chain method arguments

### DIFF
--- a/lib/rubocop/cop/rails/presence.rb
+++ b/lib/rubocop/cop/rails/presence.rb
@@ -152,7 +152,7 @@ module RuboCop
 
         def receiver_used_in_chain_arguments?(receiver, chain)
           chain.arguments.any? do |arg|
-            arg == receiver || arg.each_descendant.any? { |node| node == receiver }
+            arg == receiver || arg.each_descendant.any?(receiver)
           end
         end
 

--- a/lib/rubocop/cop/rails/presence.rb
+++ b/lib/rubocop/cop/rails/presence.rb
@@ -116,6 +116,7 @@ module RuboCop
 
           redundant_receiver_and_chain(node) do |receiver, chain|
             return if ignore_chain_node?(chain) || receiver.nil?
+            return if receiver_used_in_chain_arguments?(receiver, chain)
 
             register_chain_offense(node, receiver, chain)
           end
@@ -147,6 +148,12 @@ module RuboCop
 
         def ignore_chain_node?(node)
           node.assignment? || node.operator_method?
+        end
+
+        def receiver_used_in_chain_arguments?(receiver, chain)
+          chain.arguments.any? do |arg|
+            arg == receiver || arg.each_descendant.any? { |node| node == receiver }
+          end
         end
 
         def message(node, replacement)

--- a/spec/rubocop/cop/rails/presence_spec.rb
+++ b/spec/rubocop/cop/rails/presence_spec.rb
@@ -289,6 +289,24 @@ RSpec.describe RuboCop::Cop::Rails::Presence, :config do
       RUBY
     end
 
+    it 'does not register an offense when the receiver is used in the chained method arguments' do
+      expect_no_offenses(<<~RUBY)
+        a.present? ? a.foo(a.bar) : nil
+      RUBY
+    end
+
+    it 'does not register an offense when the receiver is used in chained method keyword arguments' do
+      expect_no_offenses(<<~RUBY)
+        a.present? ? a.foo(key: a.bar) : nil
+      RUBY
+    end
+
+    it 'does not register an offense when the receiver is used in chained method arguments with blank?' do
+      expect_no_offenses(<<~RUBY)
+        a.blank? ? nil : a.foo(a.bar)
+      RUBY
+    end
+
     it 'does not register an offense when chained method is `[]`' do
       expect_no_offenses(<<~RUBY)
         a.present? ? a[1] : nil


### PR DESCRIPTION
When the receiver appears as an argument (or within an argument) of the chained method call, the cop incorrectly suggested converting to `presence&.method(args)`. This autocorrection introduces a `NoMethodError` at runtime.

```ruby
# Before: incorrectly flagged as an offense:
a.present? ? a.foo(a.bar) : nil
# Suggested correction: a.presence&.foo(a.bar)
# ^ raises NoMethodError if `a` is nil, because `a.bar` is evaluated first

a.present? ? a.foo(key: a.bar) : nil
# Same issue with keyword arguments

a.blank? ? nil : a.foo(a.bar)
# Same issue with blank?
```

This only affects the `redundant_receiver_and_chain` pattern (i.e. cases that would generate `presence&.method(args)`). The simpler `a.present? ? a : nil` → `a.presence` pattern is unaffected since no arguments are involved.

### Changes

- Added `receiver_used_in_chain_arguments?` guard in `on_if` for the `redundant_receiver_and_chain` branch
- Added 3 test cases covering positional arguments, keyword arguments, and the `blank?` variant

---

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/).
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).
