### PR TITLE
Add support for `!=` comparison to `Rails/UnknownEnv`

### DIFF
--- a/changelog/change_rails_unknown_env_support_for_inequality_comparison.md
+++ b/changelog/change_rails_unknown_env_support_for_inequality_comparison.md
@@ -1,0 +1,1 @@
+* [#1592](https://github.com/rubocop/rubocop-rails/pull/1592): Fix false negative for `!=` comparison in `Rails/UnknownEnv`. ([@lovro-bikic][])

--- a/lib/rubocop/cop/rails/unknown_env.rb
+++ b/lib/rubocop/cop/rails/unknown_env.rb
@@ -13,10 +13,12 @@ module RuboCop
       #   # bad
       #   Rails.env.proudction?
       #   Rails.env == 'proudction'
+      #   Rails.env != 'proudction'
       #
       #   # good
       #   Rails.env.production?
       #   Rails.env == 'production'
+      #   Rails.env != 'production'
       #
       # @example
       #   # bad
@@ -47,8 +49,8 @@ module RuboCop
 
         def_node_matcher :unknown_environment_equal?, <<~PATTERN
           {
-            (send #rails_env? {:== :===} $(str #unknown_env_name?))
-            (send $(str #unknown_env_name?) {:== :===} #rails_env?)
+            (send #rails_env? {:== :=== :!=} $(str #unknown_env_name?))
+            (send $(str #unknown_env_name?) {:== :=== :!=} #rails_env?)
           }
         PATTERN
 

--- a/spec/rubocop/cop/rails/unknown_env_spec.rb
+++ b/spec/rubocop/cop/rails/unknown_env_spec.rb
@@ -44,6 +44,15 @@ RSpec.describe RuboCop::Cop::Rails::UnknownEnv, :config do
         RUBY
       end
 
+      it 'registers an offense for typo of environment name with `!=` operator' do
+        expect_offense(<<~RUBY)
+          Rails.env != 'proudction'
+                       ^^^^^^^^^^^^ Unknown environment `proudction`. Did you mean `production`?
+          'developpment' != Rails.env
+          ^^^^^^^^^^^^^^ Unknown environment `developpment`. Did you mean `development`?
+        RUBY
+      end
+
       it 'registers an offense when case condition is an unknown environment name' do
         expect_offense(<<~RUBY)
           case Rails.env


### PR DESCRIPTION
Expands `Rails/UnknownEnv` so it registers offenses for unknown environment names in inequality comparisons:
```ruby
Rails.env != 'proudction'
'proudction' != Rails.env
```

At the time of writing, there are [~1.4k search results](https://github.com/search?q=%2F(Rails%5C.env%20!%3D%20%7C%20!%3D%20Rails%5C.env)%2F%20lang%3Aruby&type=code) for this pattern on GitHub.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
