### PR TITLE
[Fix #1595] Fix a false negative for `Rails/I18nLocaleTexts` when using `redirect_back_or_to`

### DIFF
--- a/changelog/fix_i18n_locale_texts_redirect_back_or_to.md
+++ b/changelog/fix_i18n_locale_texts_redirect_back_or_to.md
@@ -1,0 +1,1 @@
+* [#1595](https://github.com/rubocop/rubocop-rails/issues/1595): Fix a false negative for `Rails/I18nLocaleTexts` when using `redirect_back_or_to` with a flash message. ([@55728][])

--- a/lib/rubocop/cop/rails/i18n_locale_texts.rb
+++ b/lib/rubocop/cop/rails/i18n_locale_texts.rb
@@ -47,6 +47,28 @@ module RuboCop
       #   end
       #
       #   # bad
+      #   class PostsController < ApplicationController
+      #     def update
+      #       # ...
+      #       redirect_back_or_to root_path, alert: "Failed to update!"
+      #     end
+      #   end
+      #
+      #   # good
+      #   # config/locales/en.yml
+      #   # en:
+      #   #   posts:
+      #   #     update:
+      #   #       failure: "Failed to update!"
+      #
+      #   class PostsController < ApplicationController
+      #     def update
+      #       # ...
+      #       redirect_back_or_to root_path, alert: t(".failure")
+      #     end
+      #   end
+      #
+      #   # bad
       #   class UserMailer < ApplicationMailer
       #     def welcome(user)
       #       mail(to: user.email, subject: "Welcome to My Awesome Site")
@@ -69,7 +91,7 @@ module RuboCop
       class I18nLocaleTexts < Base
         MSG = 'Move locale texts to the locale files in the `config/locales` directory.'
 
-        RESTRICT_ON_SEND = %i[validates redirect_to redirect_back []= mail].freeze
+        RESTRICT_ON_SEND = %i[validates redirect_to redirect_back redirect_back_or_to []= mail].freeze
 
         def_node_search :validation_message, <<~PATTERN
           (pair (sym :message) $str)
@@ -98,7 +120,7 @@ module RuboCop
               add_offense(text_node)
             end
             return
-          when :redirect_to, :redirect_back
+          when :redirect_to, :redirect_back, :redirect_back_or_to
             text_node = redirect_to_flash(node).to_a.last
           when :[]=
             text_node = flash_assignment?(node)

--- a/spec/rubocop/cop/rails/i18n_locale_texts_spec.rb
+++ b/spec/rubocop/cop/rails/i18n_locale_texts_spec.rb
@@ -33,6 +33,26 @@ RSpec.describe RuboCop::Cop::Rails::I18nLocaleTexts, :config do
     RUBY
   end
 
+  it 'registers an offense when using `redirect_back_or_to` with a notice text message' do
+    expect_offense(<<~RUBY)
+      redirect_back_or_to root_path, notice: "Post created!"
+                                             ^^^^^^^^^^^^^^^ Move locale texts to the locale files in the `config/locales` directory.
+    RUBY
+  end
+
+  it 'registers an offense when using `redirect_back_or_to` with an alert text message' do
+    expect_offense(<<~RUBY)
+      redirect_back_or_to root_path, alert: "Failed to update!"
+                                            ^^^^^^^^^^^^^^^^^^^ Move locale texts to the locale files in the `config/locales` directory.
+    RUBY
+  end
+
+  it 'does not register an offense when using `redirect_back_or_to` with localized flash messages' do
+    expect_no_offenses(<<~RUBY)
+      redirect_back_or_to root_path, notice: t(".success")
+    RUBY
+  end
+
   it 'does not register an offense when using `redirect_to` with localized flash messages' do
     expect_no_offenses(<<~RUBY)
       redirect_to root_path, notice: t(".success")


### PR DESCRIPTION
Fixes #1595.

The `Rails/I18nLocaleTexts` cop did not flag inline locale strings passed as `notice` or `alert` to `redirect_back_or_to`. This was because `redirect_back_or_to` was missing from both `RESTRICT_ON_SEND` and the `case/when` branch in `on_send`.

`redirect_back_or_to` was introduced in Rails 7.0 as the preferred replacement for `redirect_back` (which is now a soft-deprecated alias). It accepts the same flash options (`notice:`, `alert:`, `flash:`), so it should be treated identically.

## Before
```ruby
# No offense detected
redirect_back_or_to root_path, alert: "Failed to update!"
```

## After
```ruby
# Offense: Move locale texts to the locale files in the `config/locales` directory.
redirect_back_or_to root_path, alert: "Failed to update!"
```

## Changes

- Added `redirect_back_or_to` to `RESTRICT_ON_SEND` and the `when` clause in `on_send`
- Added a documentation example for the `redirect_back_or_to` case
- Added tests for `redirect_back_or_to` with `notice`, `alert`, and localized messages

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/