### PR TITLE
[Fix #1602] Fix an error in `Rails/SelectMap`

### DIFF
--- a/changelog/fix_rails_select_map_crash_on_subquery_select.md
+++ b/changelog/fix_rails_select_map_crash_on_subquery_select.md
@@ -1,0 +1,1 @@
+* [#1602](https://github.com/rubocop/rubocop-rails/issues/1602): Fix an error in `Rails/SelectMap` when `.select` appears inside a subquery in an argument. ([@koic][])

--- a/lib/rubocop/cop/rails/select_map.rb
+++ b/lib/rubocop/cop/rails/select_map.rb
@@ -53,7 +53,9 @@ module RuboCop
 
           return unless select_method_nodes.one?
 
-          select_method_nodes.first
+          select_node = select_method_nodes.first
+
+          receiver_chain?(node, select_node) ? select_node : nil
         end
 
         # rubocop:disable Metrics/AbcSize
@@ -80,6 +82,18 @@ module RuboCop
                      end
 
           argument == column_name
+        end
+
+        def receiver_chain?(map_node, select_node)
+          current = map_node.receiver
+          while current
+            current = current.children.last if current.begin_type?
+            return true if current.equal?(select_node)
+            break unless current.call_type?
+
+            current = current.receiver
+          end
+          false
         end
       end
     end

--- a/spec/rubocop/cop/rails/select_map_spec.rb
+++ b/spec/rubocop/cop/rails/select_map_spec.rb
@@ -131,6 +131,12 @@ RSpec.describe RuboCop::Cop::Rails::SelectMap, :config do
     RUBY
   end
 
+  it 'does not register an offense when `.select` appears inside a subquery in the `where` argument' do
+    expect_no_offenses(<<~RUBY)
+      Model.where(other_table: { column_name: OtherModel.select(:column_name) }).map(&:column_name)
+    RUBY
+  end
+
   it 'does not register an offense when using `pluck(:column_name)`' do
     expect_no_offenses(<<~RUBY)
       Model.pluck(:column_name)


### PR DESCRIPTION
Fixes an error for `Rails/SelectMap` when `.select` appears inside a subquery in an argument (e.g. inside a `where(...)` hash). The cop previously scanned all descendants for `.select`, so it picked up a subquery `.select` whose parent is not on the receiver chain of `.map`, causing an autocorrect crash.

`find_select_node` now also verifies that the matched `.select` is on the receiver chain of `.map`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
