### PR TITLE
Fix support for shared key in database.yml

### DIFF
--- a/changelog/fix_support_for_shared_key.md
+++ b/changelog/fix_support_for_shared_key.md
@@ -1,0 +1,1 @@
+* [#1604](https://github.com/rubocop/rubocop-rails/pull/1604): Allow `DatabaseTypeResolvable` to fall back to an `adapter` configuration specified in a `shared` key. ([@codergeek121][])

--- a/lib/rubocop/cop/mixin/database_type_resolvable.rb
+++ b/lib/rubocop/cop/mixin/database_type_resolvable.rb
@@ -40,7 +40,7 @@ module RuboCop
         end
       end
 
-      def database_yaml
+      def database_yaml(environment = 'development')
         return unless File.exist?('config/database.yml')
 
         yaml = if YAML.respond_to?(:unsafe_load_file)
@@ -50,7 +50,7 @@ module RuboCop
                end
         return unless yaml.is_a? Hash
 
-        config = yaml['development']
+        config = yaml[environment]
         return unless config.is_a?(Hash)
 
         config
@@ -59,7 +59,7 @@ module RuboCop
       end
 
       def database_adapter
-        database_yaml['adapter'] || database_yaml.first.last['adapter']
+        database_yaml['adapter'] || database_yaml('shared')&.fetch('adapter') || database_yaml.first.last['adapter']
       end
     end
   end

--- a/spec/rubocop/cop/rails/bulk_change_table_spec.rb
+++ b/spec/rubocop/cop/rails/bulk_change_table_spec.rb
@@ -687,6 +687,29 @@ RSpec.describe RuboCop::Cop::Rails::BulkChangeTable, :config do
       end
     end
 
+    context 'shared key' do
+      context 'with top-level adapter configuration' do
+        let(:yaml) do
+          {
+            'shared' => {
+              'adapter' => 'postgresql'
+            },
+            'development' => {
+              'foo' => 'bar'
+            }
+          }
+        end
+
+        context 'with Rails 5.2', :rails52 do
+          it_behaves_like 'offense for postgresql'
+        end
+
+        context 'with Rails 5.1', :rails51 do
+          it_behaves_like 'no offense for postgresql'
+        end
+      end
+    end
+
     context 'invalid (e.g. ERB)' do
       before do
         allow(YAML).to receive(:load_file).with('config/database.yml') do


### PR DESCRIPTION
Fix #1604. Rails allows specifying defaults in the database.yml by using the `shared` key. DatabaseTypeResolvable did not support this and broke cops if the adapter is specified via the shared key, even though it's a valid database configuration.