### PR TITLE
Add new `Rails/InBatchesMigrationTransaction` cop

### DIFF
--- a/changelog/add_rails_in_batches_migration_transaction_cop.md
+++ b/changelog/add_rails_in_batches_migration_transaction_cop.md
@@ -1,0 +1,1 @@
+* [#1601](https://github.com/rubocop/rubocop-rails/issues/1601): Add new Rails/InBatchesMigrationTransaction cop. ([@bart-westenenk-bex][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -665,6 +665,13 @@ Rails/IgnoredSkipActionFilterOption:
     - '**/app/controllers/**/*.rb'
     - '**/app/mailers/**/*.rb'
 
+Rails/InBatchesMigrationTransaction:
+  Description: 'Check for `in_batches` block usage in migrations without `disable_ddl_transaction!`.'
+  Enabled: pending
+  VersionAdded: <<next>>
+  Include:
+    - db/**/*.rb
+
 Rails/IndexBy:
   Description: 'Prefer `index_by` over `each_with_object`, `to_h`, or `map`.'
   Enabled: true

--- a/lib/rubocop/cop/rails/in_batches_migration_transaction.rb
+++ b/lib/rubocop/cop/rails/in_batches_migration_transaction.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Rails
+      # Checks that a in_batches block is not part of an implicit ddl transaction in a migration.
+      #
+      # @example
+      #
+      #  # good
+      #  class SomeMigration < ActiveRecord::Migration[8.0]
+      #   disable_ddl_transaction!
+      #   def up
+      #    Model.in_batches do |relation|
+      #     # Optionally, you can consider wrapping the
+      #     Model.transaction do
+      #      # Your batch processing logic here
+      #     end
+      #    end
+      #   end
+      #  end
+      #
+      #  # bad
+      #  class SomeMigration < ActiveRecord::Migration[8.0]
+      #   def up
+      #    Model.in_batches do |relation|
+      #      # Your batch processing logic here
+      #    end
+      #   end
+      #  end
+      class InBatchesMigrationTransaction < Base
+        include MigrationsHelper
+
+        MSG = 'Do not use `in_batches` without `disable_ddl_transaction!` in migrations.'
+
+        RESTRICT_ON_SEND = %i[in_batches].freeze
+
+        def on_send(node)
+          return unless in_migration?(node)
+          return if disable_ddl_transaction?(node)
+
+          add_offense(node)
+        end
+
+        private
+
+        def disable_ddl_transaction?(node)
+          node.each_ancestor(:class).any? do |class_node|
+            class_node.body.each_child_node(:send).any? do |send_node|
+              send_node.method?(:disable_ddl_transaction!)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/rails_cops.rb
+++ b/lib/rubocop/cop/rails_cops.rb
@@ -11,6 +11,7 @@ require_relative 'mixin/routes_helper'
 require_relative 'mixin/target_rails_version'
 
 require_relative 'rails/action_controller_flash_before_render'
+require_relative 'rails/in_batches_migration_transaction'
 require_relative 'rails/strong_parameters_expect'
 require_relative 'rails/action_controller_test_case'
 require_relative 'rails/action_filter'

--- a/spec/rubocop/cop/rails/in_batches_migration_transaction_spec.rb
+++ b/spec/rubocop/cop/rails/in_batches_migration_transaction_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Rails::InBatchesMigrationTransaction, :config do
+  %i[up down change].each do |method_name|
+    context "when using in_batches in a #{method_name} method" do
+      context 'without disable_ddl_transaction!' do
+        it 'registers an offense when using in_batches with update_all' do
+          expect_offense(<<~RUBY)
+            class SomeMigration < ActiveRecord::Migration[8.0]
+              def #{method_name}
+                Model.in_batches.update_all(active: true)
+                ^^^^^^^^^^^^^^^^ Do not use `in_batches` without `disable_ddl_transaction!` in migrations.
+              end
+            end
+          RUBY
+        end
+
+        it 'registers an offense when using in_batches with enumeration' do
+          expect_offense(<<~RUBY)
+            class SomeMigration < ActiveRecord::Migration[8.0]
+              def #{method_name}
+                Model.in_batches.each do |relation|
+                ^^^^^^^^^^^^^^^^ Do not use `in_batches` without `disable_ddl_transaction!` in migrations.
+                  # some batch processing here, e.g. relation.update_all(active: true)
+                end
+              end
+            end
+          RUBY
+        end
+      end
+
+      context 'with disable_ddl_transaction!' do
+        it 'does not register an offense when using in_batches with update_all' do
+          expect_no_offenses(<<~RUBY)
+            class SomeMigration < ActiveRecord::Migration[8.0]
+              disable_ddl_transaction!
+
+              def #{method_name}
+                Model.in_batches.update_all(active: true)
+              end
+            end
+          RUBY
+        end
+
+        it 'does not register an offense when using in_batches with enumeration' do
+          expect_no_offenses(<<~RUBY)
+            class SomeMigration < ActiveRecord::Migration[8.0]
+              disable_ddl_transaction!
+
+              def #{method_name}
+                Model.in_batches.each do |relation|
+                  # some batch processing here, e.g. relation.update_all(active: true)
+                end
+              end
+            end
+          RUBY
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This new cop enforces the use of `disable_ddl_transaction!` when a migration uses `in_batches` to go over a lot of records.
In general, when you use `in_batches` within a transaction you will negate the effect of using `in_batches` and when deploying the migration you will put a full write lock on the full relation instead of the batched version of it.

Since you must always check yourself if it is sensible to use `disable_ddl_transaction!`, I have not implemented an autocorrector for this cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide). ==> https://github.com/rubocop/rails-style-guide/pull/377

[1]: https://chris.beams.io/posts/git-commit/
