### PR TITLE
Add `AllowedPredicates` configuration option to `Rails/Env`

### DIFF
--- a/changelog/change_allow_local_in_rails_env.md
+++ b/changelog/change_allow_local_in_rails_env.md
@@ -1,0 +1,1 @@
+* [#1615](https://github.com/rubocop/rubocop-rails/pull/1615): Allow `Rails.env.local?` in `Rails/Env`. ([@dduugg][])

--- a/lib/rubocop/cop/rails/env.rb
+++ b/lib/rubocop/cop/rails/env.rb
@@ -5,22 +5,30 @@ module RuboCop
     module Rails
       # Checks for usage of `Rails.env` which can be replaced with Feature Flags
       #
+      # Although `local?` is a form of an environment-specific check, it is allowed because
+      # it cannot be used to control overall environment rollout, but it can be helpful to
+      # distinguish or protect code that is explicitly written to only ever execute in a
+      # dev or test environment. `local?` is also a form of a feature flag.
+      #
       # @example
       #
       #   # bad
-      #   Rails.env.production? || Rails.env.local?
+      #   Rails.env.production? || Rails.env.demo?
       #
       #   # good
       #   if FeatureFlag.enabled?(:new_feature)
       #     # new feature code
       #   end
       #
+      #   # good
+      #   raise unless Rails.env.local?
+      #
       class Env < Base
         MSG = 'Use Feature Flags or config instead of `Rails.env`.'
         RESTRICT_ON_SEND = %i[env].freeze
         # This allow list is derived from:
         # (Rails.env.methods - Object.instance_methods).select { |m| m.to_s.end_with?('?') }
-        # and then removing the environment specific methods like development?, test?, production?, local?
+        # and then removing the environment specific methods like development?, test?, production?
         ALLOWED_LIST = Set.new(
           %i[
             unicode_normalized?
@@ -38,6 +46,7 @@ module RuboCop
             valid_encoding?
             ascii_only?
             between?
+            local?
           ]
         ).freeze
 

--- a/spec/rubocop/cop/rails/env_spec.rb
+++ b/spec/rubocop/cop/rails/env_spec.rb
@@ -35,6 +35,12 @@ RSpec.describe RuboCop::Cop::Rails::Env, :config do
     RUBY
   end
 
+  it 'does not register an offense for `Rails.env.local?`' do
+    expect_no_offenses(<<~RUBY)
+      raise unless Rails.env.local?
+    RUBY
+  end
+
   it 'does not register an offense for unrelated config' do
     expect_no_offenses(<<~RUBY)
       Rails.environment


### PR DESCRIPTION
## Summary

Replace `Rails/Env`'s hard-coded `ALLOWED_LIST` constant with a configurable `AllowedPredicates` option. The default value is the previous `ALLOWED_LIST` content — `String` / `StringInquirer` predicates like `empty?`, `match?`, `between?` — so out-of-the-box behavior is unchanged.

The motivation is to let users exempt additional predicates from the cop without forking or disabling it. Two concrete cases this addresses:

- **`Rails.env.local?`** — the built-in alias for "development or test", introduced in Rails 7.1. Some users treat it as a legitimate guard rail for code that should only ever execute in dev or test (sanity checks, devtools, seed data) rather than as an environment-rollout mechanism, and want it exempt from the cop.
- **Custom predicates monkey-patched onto the environment inquirer.** Apps with their own `Rails.env.beta_user?` / `Rails.env.internal?` style helpers can now opt those in.

The configured value **fully replaces** the default — it is not merged. Users who want to inherit the defaults and add to them can opt in via RuboCop's [`inherit_mode`](https://docs.rubocop.org/rubocop/configuration.html#merging-arrays-using-inherit_mode):

```yaml
Rails/Env:
  AllowedPredicates:
    - empty?
    - match?
    - local?
```

## Compatibility with `Rails/EnvLocal`

[`Rails/EnvLocal`](https://docs.rubocop.org/rubocop-rails/latest/cops_rails.html#railsenvlocal) autocorrects `Rails.env.development? || Rails.env.test?` → `Rails.env.local?`. Under the default `AllowedPredicates`, `Rails/Env` will still flag the autocorrected `Rails.env.local?`. Users who run both cops can now resolve that conflict by including `local?` in their `AllowedPredicates` rather than disabling either cop.

## Test coverage

A new context block uses `let(:cop_config)` to override `AllowedPredicates` and verifies (a) a predicate in the override is not flagged, and (b) a predicate omitted from the override is flagged — confirming the override is exhaustive (no implicit merge with defaults).

## Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote good commit messages.
* [ ] Commit message starts with `[Fix #issue-number]` (no related issue).
* [x] Feature branch is up-to-date with `master`.
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`.
* [x] Added an entry to the changelog folder.
* [ ] If this is a new cop, consider making a corresponding update to the Rails Style Guide (N/A — existing cop).
