### PR TITLE
Fix false positives in `Rails/StrongParametersExpect`

### DIFF
--- a/changelog/fix_false_positives_for_rails_strong_parameters_expect.md
+++ b/changelog/fix_false_positives_for_rails_strong_parameters_expect.md
@@ -1,0 +1,1 @@
+* [#1616](https://github.com/rubocop/rubocop-rails/pull/1616): Fix false positives in `Rails/StrongParametersExpect` when using nil-safe conversion methods such as `to_i`, `to_s`, `to_a`, `to_f`, and `to_h` on `params[:key]`. ([@koic][])

--- a/lib/rubocop/cop/rails/strong_parameters_expect.rb
+++ b/lib/rubocop/cop/rails/strong_parameters_expect.rb
@@ -8,7 +8,7 @@ module RuboCop
       # In the following cases, `params[:key]` is treated as a key that is expected to be passed from the HTTP client,
       # and the cop detects it using the `expect` method.
       #
-      # - Method calls on `params[:key]` without comparison methods
+      # - Method calls on `params[:key]` without comparison methods and nil-safe conversion methods
       # - Passing `params[:key]` as an argument to finder methods that raise on missing records
       # - Strong parameter methods using `require` or `permit`
       #
@@ -54,6 +54,7 @@ module RuboCop
         MSG = 'Use `%<prefer>s` instead.'
         RESTRICT_ON_SEND = %i[[] require permit].freeze
         PRESENCE_CHECK_METHODS = %i[nil? blank? present? presence].freeze
+        NIL_SAFE_CONVERSION_METHODS = %i[to_a to_f to_h to_i to_s].freeze
         RAISING_FINDER_METHODS = %i[find find_by! find_sole_by].freeze
 
         minimum_target_rails_version 8.0
@@ -131,9 +132,11 @@ module RuboCop
           return false unless parent.call_type?
 
           if parent.receiver == node
-            return false if parent.comparison_method?
+            return false if parent.comparison_method? || parent.method?(:[])
 
-            !parent.method?(:[]) && !PRESENCE_CHECK_METHODS.include?(parent.method_name)
+            method_name = parent.method_name
+
+            !PRESENCE_CHECK_METHODS.include?(method_name) && !NIL_SAFE_CONVERSION_METHODS.include?(method_name)
           else
             raising_finder_method?(parent)
           end

--- a/spec/rubocop/cop/rails/strong_parameters_expect_spec.rb
+++ b/spec/rubocop/cop/rails/strong_parameters_expect_spec.rb
@@ -25,6 +25,36 @@ RSpec.describe RuboCop::Cop::Rails::StrongParametersExpect, :config do
       RUBY
     end
 
+    it 'does not register an offense when using `key = params[:key].to_i`' do
+      expect_no_offenses(<<~RUBY)
+        params[:key].to_i
+      RUBY
+    end
+
+    it 'does not register an offense when using `params[:key].to_s`' do
+      expect_no_offenses(<<~RUBY)
+        params[:key].to_s
+      RUBY
+    end
+
+    it 'does not register an offense when using `params[:key].to_a`' do
+      expect_no_offenses(<<~RUBY)
+        params[:key].to_a
+      RUBY
+    end
+
+    it 'does not register an offense when using `params[:key].to_f`' do
+      expect_no_offenses(<<~RUBY)
+        params[:key].to_f
+      RUBY
+    end
+
+    it 'does not register an offense when using `params[:key].to_h`' do
+      expect_no_offenses(<<~RUBY)
+        params[:key].to_h
+      RUBY
+    end
+
     it "does not register an offense when using `params[:key] == 'value'`" do
       expect_no_offenses(<<~RUBY)
         params[:key] == 'value'


### PR DESCRIPTION
This PR fixes false positives in `Rails/StrongParametersExpect` when `params[:key]` is followed by a nil-safe conversion method such as `to_i`, `to_s`, `to_a`, `to_f`, or `to_h`.

These methods are defined on `NilClass` and return a sensible default (e.g., `nil.to_i` returns `0`) without raising, so the caller is intentionally treating the parameter as optional. This is the same rationale behind the existing `PRESENCE_CHECK_METHODS` allow list (`nil?`, `blank?`, `present?`, `presence`).

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
