### PR TITLE
[Cop lazy loading] Fix application of `MigrationFileSkippable` to all cops

### DIFF
--- a/changelog/fix_prepend_migration_file_skippable.md
+++ b/changelog/fix_prepend_migration_file_skippable.md
@@ -1,0 +1,1 @@
+* [#1619](https://github.com/rubocop/rubocop-rails/pull/1619): Fix `MigratedSchemaVersion` setting so it works for all cops. ([@lovro-bikic][])

--- a/lib/rubocop-rails.rb
+++ b/lib/rubocop-rails.rb
@@ -12,7 +12,8 @@ require_relative 'rubocop/rails/plugin'
 require_relative 'rubocop/cop/rails_cops'
 
 require_relative 'rubocop/rails/migration_file_skippable'
-RuboCop::Rails::MigrationFileSkippable.apply_to_cops!
+
+RuboCop::Cop::Base.prepend(RuboCop::Rails::MigrationFileSkippable)
 
 RuboCop::Cop::Style::HashExcept.minimum_target_ruby_version(2.0)
 

--- a/lib/rubocop/rails/migration_file_skippable.rb
+++ b/lib/rubocop/rails/migration_file_skippable.rb
@@ -29,10 +29,6 @@ module RuboCop
         super if method(__method__).super_method
       end
 
-      def self.apply_to_cops!
-        RuboCop::Cop::Registry.all.each { |cop| cop.prepend(MigrationFileSkippable) }
-      end
-
       private
 
       def already_migrated_file?


### PR DESCRIPTION
Fixes `MigrationFileSkippable` module so it prepends to `RuboCop::Cop::Base` instead of prepending to each individual cop class.

`MigrationFileSkippable` is meant to be applied to all cops, but this currently isn't the case if there are plugins loaded after `rubocop-rails`. For example, if your RuboCop config is:
```yml
# .rubocop.yml
plugins:
  - rubocop-rails
  - rubocop-rspec
```
`rubocop-rails` will be required before `rubocop-rspec`, and when `RuboCop::Cop::Registry.all.each` runs, `MigrationFileSkippable` won't be prepended to `rubocop-rspec` cops because they haven't been added to the registry yet.

This PR changes the implementation so that this module is instead prepended to `RuboCop::Cop::Base`, thereby making it automatically available to all cops, regardless of when they're loaded.

This PR is also a part of the cop lazy-loading proposal: https://github.com/rubocop/rubocop/issues/14983. Not using `Registry.all` is a prerequisite for lazy-loading to work with this gem.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
