### PR TITLE
[Fix #1620] Fix false positives in `Rails/StrongParametersExpect`

### DIFF
--- a/changelog/fix_false_positives_for_rails_strong_parameters_expect_with_type_check_methods.md
+++ b/changelog/fix_false_positives_for_rails_strong_parameters_expect_with_type_check_methods.md
@@ -1,0 +1,1 @@
+* [#1620](https://github.com/rubocop/rubocop-rails/issues/1620): Fix false positives in `Rails/StrongParametersExpect` when using type-check methods such as `is_a?`, `kind_of?`, and `instance_of?` on `params[:key]`. ([@koic][])

--- a/lib/rubocop/cop/rails/strong_parameters_expect.rb
+++ b/lib/rubocop/cop/rails/strong_parameters_expect.rb
@@ -8,7 +8,8 @@ module RuboCop
       # In the following cases, `params[:key]` is treated as a key that is expected to be passed from the HTTP client,
       # and the cop detects it using the `expect` method.
       #
-      # - Method calls on `params[:key]` without comparison methods and nil-safe conversion methods
+      # - Method calls on `params[:key]` without comparison methods or methods that are safe to call
+      #   on `nil` (such as `to_i`, `to_s`, or `is_a?`)
       # - Passing `params[:key]` as an argument to finder methods that raise on missing records
       # - Strong parameter methods using `require` or `permit`
       #
@@ -54,7 +55,7 @@ module RuboCop
         MSG = 'Use `%<prefer>s` instead.'
         RESTRICT_ON_SEND = %i[[] require permit].freeze
         PRESENCE_CHECK_METHODS = %i[nil? blank? present? presence].freeze
-        NIL_SAFE_CONVERSION_METHODS = %i[to_a to_f to_h to_i to_s].freeze
+        NIL_SAFE_METHODS = %i[instance_of? is_a? kind_of? to_a to_f to_h to_i to_s].freeze
         RAISING_FINDER_METHODS = %i[find find_by! find_sole_by].freeze
 
         minimum_target_rails_version 8.0
@@ -136,7 +137,7 @@ module RuboCop
 
             method_name = parent.method_name
 
-            !PRESENCE_CHECK_METHODS.include?(method_name) && !NIL_SAFE_CONVERSION_METHODS.include?(method_name)
+            !PRESENCE_CHECK_METHODS.include?(method_name) && !NIL_SAFE_METHODS.include?(method_name)
           else
             raising_finder_method?(parent)
           end

--- a/spec/rubocop/cop/rails/strong_parameters_expect_spec.rb
+++ b/spec/rubocop/cop/rails/strong_parameters_expect_spec.rb
@@ -55,6 +55,24 @@ RSpec.describe RuboCop::Cop::Rails::StrongParametersExpect, :config do
       RUBY
     end
 
+    it 'does not register an offense when using `params[:key].is_a?(String)`' do
+      expect_no_offenses(<<~RUBY)
+        params[:key].is_a?(String)
+      RUBY
+    end
+
+    it 'does not register an offense when using `params[:key].kind_of?(String)`' do
+      expect_no_offenses(<<~RUBY)
+        params[:key].kind_of?(String)
+      RUBY
+    end
+
+    it 'does not register an offense when using `params[:key].instance_of?(String)`' do
+      expect_no_offenses(<<~RUBY)
+        params[:key].instance_of?(String)
+      RUBY
+    end
+
     it "does not register an offense when using `params[:key] == 'value'`" do
       expect_no_offenses(<<~RUBY)
         params[:key] == 'value'


### PR DESCRIPTION
This PR fixes false positives in `Rails/StrongParametersExpect` when `params[:key]` is followed by a type-check method such as `is_a?`, `kind_of?`, or `instance_of?`.

These methods are inherited by `NilClass` from `BasicObject`/`Object`, so calling them on a missing parameter simply returns `false` instead of raising. Callers using `params[:key].is_a?(...)` are intentionally treating the parameter as optional, and rewriting the expression to `params.expect(:key).is_a?(...)` changes that semantics because `expect` raises `ActionController::ParameterMissing` when the parameter is absent.

Since this shares the same "safe to call on `nil`" rationale as the existing `NIL_SAFE_CONVERSION_METHODS` (`to_a`, `to_f`, `to_h`, `to_i`, `to_s`), the constant is renamed to `NIL_SAFE_METHODS` and the type-check methods are merged into it rather than introducing a separate constant.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
