### PR TITLE
[Fix #1622] Fix false positives in `Rails/StrongParametersExpect`

### DIFF
--- a/changelog/fix_false_positives_for_rails_strong_parameters_expect_with_key_check_methods.md
+++ b/changelog/fix_false_positives_for_rails_strong_parameters_expect_with_key_check_methods.md
@@ -1,0 +1,1 @@
+* [#1622](https://github.com/rubocop/rubocop-rails/issues/1622): Fix false positives in `Rails/StrongParametersExpect` when using key-check methods such as `key?`, `has_key?`, `include?`, and `member?` on `params[:key]`. ([@koic][])

--- a/lib/rubocop/cop/rails/strong_parameters_expect.rb
+++ b/lib/rubocop/cop/rails/strong_parameters_expect.rb
@@ -8,8 +8,8 @@ module RuboCop
       # In the following cases, `params[:key]` is treated as a key that is expected to be passed from the HTTP client,
       # and the cop detects it using the `expect` method.
       #
-      # - Method calls on `params[:key]` without comparison methods or methods that are safe to call
-      #   on `nil` (such as `to_i`, `to_s`, or `is_a?`)
+      # - Method calls on `params[:key]` without comparison methods, methods that are safe to call
+      #   on `nil` (such as `to_i`, `to_s`, or `is_a?`), or key-check methods such as `key?`
       # - Passing `params[:key]` as an argument to finder methods that raise on missing records
       # - Strong parameter methods using `require` or `permit`
       #
@@ -56,6 +56,7 @@ module RuboCop
         RESTRICT_ON_SEND = %i[[] require permit].freeze
         PRESENCE_CHECK_METHODS = %i[nil? blank? present? presence].freeze
         NIL_SAFE_METHODS = %i[instance_of? is_a? kind_of? to_a to_f to_h to_i to_s].freeze
+        KEY_CHECK_METHODS = %i[key? has_key? include? member?].freeze
         RAISING_FINDER_METHODS = %i[find find_by! find_sole_by].freeze
 
         minimum_target_rails_version 8.0
@@ -137,7 +138,9 @@ module RuboCop
 
             method_name = parent.method_name
 
-            !PRESENCE_CHECK_METHODS.include?(method_name) && !NIL_SAFE_METHODS.include?(method_name)
+            !PRESENCE_CHECK_METHODS.include?(method_name) &&
+              !NIL_SAFE_METHODS.include?(method_name) &&
+              !KEY_CHECK_METHODS.include?(method_name)
           else
             raising_finder_method?(parent)
           end

--- a/spec/rubocop/cop/rails/strong_parameters_expect_spec.rb
+++ b/spec/rubocop/cop/rails/strong_parameters_expect_spec.rb
@@ -73,6 +73,30 @@ RSpec.describe RuboCop::Cop::Rails::StrongParametersExpect, :config do
       RUBY
     end
 
+    it 'does not register an offense when using `params[:key].key?(:inner)`' do
+      expect_no_offenses(<<~RUBY)
+        params[:key].key?(:inner)
+      RUBY
+    end
+
+    it 'does not register an offense when using `params[:key].has_key?(:inner)`' do
+      expect_no_offenses(<<~RUBY)
+        params[:key].has_key?(:inner)
+      RUBY
+    end
+
+    it 'does not register an offense when using `params[:key].include?(:inner)`' do
+      expect_no_offenses(<<~RUBY)
+        params[:key].include?(:inner)
+      RUBY
+    end
+
+    it 'does not register an offense when using `params[:key].member?(:inner)`' do
+      expect_no_offenses(<<~RUBY)
+        params[:key].member?(:inner)
+      RUBY
+    end
+
     it "does not register an offense when using `params[:key] == 'value'`" do
       expect_no_offenses(<<~RUBY)
         params[:key] == 'value'


### PR DESCRIPTION
This PR fixes false positives in `Rails/StrongParametersExpect` when `params[:key]` is followed by a key-check method such as `key?`, `has_key?`, `include?`, or `member?`.

Callers using `params[:key].key?(:inner)` are treating `params[:key]` as a Hash and inspecting its keys, which is a different use case from what `ActionController::Parameters#expect` is designed for. `expect` declares a parameter shape and raises `ActionController::ParameterMissing` when the parameter is absent, so rewriting the expression to `params.expect(:key).key?(:inner)` both raises in the missing case and produces a value on which `key?` is no longer meaningful.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
