### PR TITLE
Fix false positives for try and try! in Rails/StrongParametersExpect

### DIFF
--- a/changelog/fix_false_positives_for_try_in_rails_strong_parameters_expect.md
+++ b/changelog/fix_false_positives_for_try_in_rails_strong_parameters_expect.md
@@ -1,0 +1,1 @@
+* [#1627](https://github.com/rubocop/rubocop-rails/pull/1627): Fix false positives in `Rails/StrongParametersExpect` for usages like `params[:key].try(:method)` and `params[:key].try!(:method)`. ([@nicholasdower][])

--- a/lib/rubocop/cop/rails/strong_parameters_expect.rb
+++ b/lib/rubocop/cop/rails/strong_parameters_expect.rb
@@ -55,7 +55,7 @@ module RuboCop
         MSG = 'Use `%<prefer>s` instead.'
         RESTRICT_ON_SEND = %i[[] require permit].freeze
         PRESENCE_CHECK_METHODS = %i[nil? blank? present? presence].freeze
-        NIL_SAFE_METHODS = %i[instance_of? is_a? kind_of? to_a to_f to_h to_i to_s].freeze
+        NIL_SAFE_METHODS = %i[instance_of? is_a? kind_of? to_a to_f to_h to_i to_s try try!].freeze
         KEY_CHECK_METHODS = %i[key? has_key? include? member?].freeze
         RAISING_FINDER_METHODS = %i[find find_by! find_sole_by].freeze
 

--- a/spec/rubocop/cop/rails/strong_parameters_expect_spec.rb
+++ b/spec/rubocop/cop/rails/strong_parameters_expect_spec.rb
@@ -73,6 +73,18 @@ RSpec.describe RuboCop::Cop::Rails::StrongParametersExpect, :config do
       RUBY
     end
 
+    it 'does not register an offense when using `params[:key].try(:method)`' do
+      expect_no_offenses(<<~RUBY)
+        params[:key].try(:method)
+      RUBY
+    end
+
+    it 'does not register an offense when using `params[:key].try!(:method)`' do
+      expect_no_offenses(<<~RUBY)
+        params[:key].try!(:method)
+      RUBY
+    end
+
     it 'does not register an offense when using `params[:key].key?(:inner)`' do
       expect_no_offenses(<<~RUBY)
         params[:key].key?(:inner)


### PR DESCRIPTION
Fixes false positives in `Rails/StrongParametersExpect` for usages like `params[:key].try(:method)` and `params[:key].try!(:method)`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* x ] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
