### PR TITLE
[Fix #1630] Fix a false positive in `Rails/StrongParametersExpect`

### DIFF
--- a/changelog/fix_false_positives_for_rails_strong_parameters_expect_with_negation.md
+++ b/changelog/fix_false_positives_for_rails_strong_parameters_expect_with_negation.md
@@ -1,0 +1,1 @@
+* [#1630](https://github.com/rubocop/rubocop-rails/issues/1630): Fix a false positive in `Rails/StrongParametersExpect` when negating `params[:key]` with `!`, such as `!params[:key]`. ([@koic][])

--- a/lib/rubocop/cop/rails/strong_parameters_expect.rb
+++ b/lib/rubocop/cop/rails/strong_parameters_expect.rb
@@ -60,7 +60,7 @@ module RuboCop
         # Covers presence/nil checks, nil-safe conversions and type checks, key-check methods,
         # and collection methods that imply `params[:key]` is a Hash/Array.
         IGNORED_METHODS = %i[
-          blank? compact compact! compact_blank compact_blank! deep_merge deep_merge!
+          ! blank? compact compact! compact_blank compact_blank! deep_merge deep_merge!
           delete delete_if dig each except exclude? extract! fetch has_key? has_value?
           include? instance_of? is_a? keep_if key? keys kind_of? member? merge merge!
           nil? presence present? reverse_merge reverse_merge! slice stringify_keys

--- a/spec/rubocop/cop/rails/strong_parameters_expect_spec.rb
+++ b/spec/rubocop/cop/rails/strong_parameters_expect_spec.rb
@@ -207,6 +207,18 @@ RSpec.describe RuboCop::Cop::Rails::StrongParametersExpect, :config do
       RUBY
     end
 
+    it 'does not register an offense when using `!params[:key]`' do
+      expect_no_offenses(<<~RUBY)
+        !params[:key]
+      RUBY
+    end
+
+    it 'does not register an offense when using `condition && !params[:key]`' do
+      expect_no_offenses(<<~RUBY)
+        condition && !params[:key]
+      RUBY
+    end
+
     it 'does not register an offense when using `params[:key].blank?`' do
       expect_no_offenses(<<~RUBY)
         params[:key].blank?


### PR DESCRIPTION
This PR fixes a false positive in `Rails/StrongParametersExpect` when negating `params[:key]` with `!`, such as `!params[:key]` or `condition && !params[:key]`.

Negating `params[:key]` is a way of checking for an optional parameter, where a missing value is expected and should be falsy. Rewriting `!params[:key]` to `!params.expect(:key)` changes the runtime behavior, because `params.expect(:key)` raises `ActionController::ParameterMissing` when the parameter is absent instead of returning a falsy value.

Fixes #1630.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
