### PR TITLE
[Doc] Document additional unsafety of `Rails/StrongParametersExpect`

### DIFF
--- a/lib/rubocop/cop/rails/strong_parameters_expect.rb
+++ b/lib/rubocop/cop/rails/strong_parameters_expect.rb
@@ -23,6 +23,12 @@ module RuboCop
       #   incompatibility introduced for valid reasons by the `expect` method, which aligns better with
       #   strong parameter conventions.
       #
+      #   It is also unsafe because `expect` is stricter about the structure of the parameters than
+      #   `require`/`permit`. Nested attributes that hold an array of records need an extra array wrapper,
+      #   such as `expect(user: [{ pets_attributes: [[:name]] }])`. The cop cannot tell a single nested hash
+      #   from an array of nested hashes, so it always generates the single-hash form, which can turn
+      #   a previously successful request into a failure.
+      #
       # @example
       #
       #   # bad


### PR DESCRIPTION
The `@safety` note previously mentioned only the 500 to 400 status change.

However, `ActionController::Parameters#expect` is also stricter about the structure of the parameters than `require`/`permit`.
    
Nested attributes that hold an array of records need an extra array wrapper, but the cop cannot statically tell a single nested hash from an array of nested hashes, so it always emits the single-hash form. This can turn a request that previously succeeded into a failure when the data is actually an array of records.

Closes #1418 and #1429.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
