### PR TITLE
[Fix #1418] Fix a false positive for `Rails/StrongParametersExpect`

### DIFF
--- a/changelog/fix_a_false_positive_for_rails_strong_parameters_expect_with_array_require.md
+++ b/changelog/fix_a_false_positive_for_rails_strong_parameters_expect_with_array_require.md
@@ -1,0 +1,1 @@
+* [#1418](https://github.com/rubocop/rubocop-rails/issues/1418): Fix a false positive for `Rails/StrongParametersExpect` when `require` is given an array literal, such as `params.require([:foo, :bar]).permit(:baz)`. ([@koic][])

--- a/lib/rubocop/cop/rails/strong_parameters_expect.rb
+++ b/lib/rubocop/cop/rails/strong_parameters_expect.rb
@@ -76,10 +76,12 @@ module RuboCop
           (send (send nil? :params) :[] $_)
         PATTERN
 
+        # `require` with an array literal expects multiple top-level keys and has no single `expect` equivalent,
+        # so such calls are excluded to avoid generating broken code.
         def_node_matcher :params_require_permit, <<~PATTERN
           $(call
             $(call
-              (send nil? :params) :require _) :permit _+)
+              (send nil? :params) :require !array) :permit _+)
         PATTERN
 
         def_node_matcher :params_permit_require, <<~PATTERN

--- a/spec/rubocop/cop/rails/strong_parameters_expect_spec.rb
+++ b/spec/rubocop/cop/rails/strong_parameters_expect_spec.rb
@@ -513,6 +513,12 @@ RSpec.describe RuboCop::Cop::Rails::StrongParametersExpect, :config do
       RUBY
     end
 
+    it 'does not register an offense when using `params.require([:foo, :bar]).permit(:baz)`' do
+      expect_no_offenses(<<~RUBY)
+        params.require([:foo, :bar]).permit(:baz)
+      RUBY
+    end
+
     it 'does not register an offense when using `params.require(:name)`' do
       expect_no_offenses(<<~RUBY)
         params.require(:name)


### PR DESCRIPTION
`params.require([:foo, :bar])` expects multiple top-level keys and returns an array, which has no single-call `expect` equivalent. The cop nevertheless rewrote `params.require([:foo, :bar]).permit(:baz)` to `params.expect([:foo, :bar] => [:baz])`, which does not behave the same way and breaks the request.

Exclude `require` calls whose argument is an array literal so the cop no longer flags or autocorrects them.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
