### PR TITLE
Allow `inspect` in Rails/StrongParametersExpect

### DIFF
--- a/changelog/fix_strong_parameters_inspect.md
+++ b/changelog/fix_strong_parameters_inspect.md
@@ -1,0 +1,1 @@
+* [#1635](https://github.com/rubocop/rubocop-rails/issues/1635): Fix `Rails/StrongParametersExpect` to allow `params[:foo].inspect`. ([@jdelStrother][])

--- a/lib/rubocop/cop/rails/strong_parameters_expect.rb
+++ b/lib/rubocop/cop/rails/strong_parameters_expect.rb
@@ -62,7 +62,7 @@ module RuboCop
         IGNORED_METHODS = %i[
           ! blank? compact compact! compact_blank compact_blank! deep_merge deep_merge!
           delete delete_if dig each except exclude? extract! fetch has_key? has_value?
-          include? instance_of? is_a? keep_if key? keys kind_of? member? merge merge!
+          include? inspect instance_of? is_a? keep_if key? keys kind_of? member? merge merge!
           nil? presence present? reverse_merge reverse_merge! slice stringify_keys
           to_a to_f to_h to_hash to_i to_s to_unsafe_h to_unsafe_hash
           transform_keys transform_keys! transform_values transform_values! try try!

--- a/spec/rubocop/cop/rails/strong_parameters_expect_spec.rb
+++ b/spec/rubocop/cop/rails/strong_parameters_expect_spec.rb
@@ -37,6 +37,12 @@ RSpec.describe RuboCop::Cop::Rails::StrongParametersExpect, :config do
       RUBY
     end
 
+    it 'does not register an offense when using `params[:key].inspect`' do
+      expect_no_offenses(<<~RUBY)
+        params[:key].inspect
+      RUBY
+    end
+
     it 'does not register an offense when using `params[:key].to_a`' do
       expect_no_offenses(<<~RUBY)
         params[:key].to_a


### PR DESCRIPTION
For us, a common Rails/StrongParametersExpect error was from calling `inspect` on the params - eg

```
app/controllers/api/oauth2_controller.rb:52:77: C: [Correctable] Rails/StrongParametersExpect: Use expect(:grant_type) instead.
        raise BadParameters.new("Unsupported grant_type #{params[:grant_type].inspect}") unless GRANT_TYPES.include?(params[:grant_type])
                                                                ^^^^^^^^^^^^^
```

WDYT to adding `inspect` to the IGNORED_METHODS list?