### PR TITLE
[Fix #1574] Fix an invalid autocorrection for `Rails/StrongParametersExpect`

### DIFF
--- a/changelog/fix_an_invalid_autocorrect_for_rails_strong_parameters_expect_with_dynamic_permit_argument.md
+++ b/changelog/fix_an_invalid_autocorrect_for_rails_strong_parameters_expect_with_dynamic_permit_argument.md
@@ -1,0 +1,1 @@
+* [#1574](https://github.com/rubocop/rubocop-rails/issues/1574): Fix an invalid autocorrection for `Rails/StrongParametersExpect` when `permit` receives a single dynamic argument, such as `params.require(:user).permit(permitted_attributes)`. ([@koic][])

--- a/lib/rubocop/cop/rails/strong_parameters_expect.rb
+++ b/lib/rubocop/cop/rails/strong_parameters_expect.rb
@@ -84,10 +84,16 @@ module RuboCop
 
         # `require` with an array literal expects multiple top-level keys and has no single `expect` equivalent,
         # so such calls are excluded to avoid generating broken code.
+        # A single dynamic argument to `permit` (such as a method call or variable that may return an array)
+        # has no safe `expect` rewrite, because the cop cannot tell whether the value is a list of attributes
+        # or a nested hash. Such calls are excluded to avoid generating broken code.
         def_node_matcher :params_require_permit, <<~PATTERN
-          $(call
+          [
             $(call
-              (send nil? :params) :require !array) :permit _+)
+              $(call
+                (send nil? :params) :require !array) :permit _+)
+            !(call _ :permit {call lvar ivar cvar gvar const})
+          ]
         PATTERN
 
         def_node_matcher :params_permit_require, <<~PATTERN

--- a/spec/rubocop/cop/rails/strong_parameters_expect_spec.rb
+++ b/spec/rubocop/cop/rails/strong_parameters_expect_spec.rb
@@ -513,6 +513,19 @@ RSpec.describe RuboCop::Cop::Rails::StrongParametersExpect, :config do
       RUBY
     end
 
+    it 'does not register an offense when `permit` receives a single method call argument' do
+      expect_no_offenses(<<~RUBY)
+        params.require(:moderation_comment).permit(policy(ModerationComment).permitted_attributes_for_create)
+      RUBY
+    end
+
+    it 'does not register an offense when `permit` receives a single variable argument' do
+      expect_no_offenses(<<~RUBY)
+        permitted_keys = %i[name age]
+        params.require(:user).permit(permitted_keys)
+      RUBY
+    end
+
     it 'does not register an offense when using `params.permit(unmatch_require_param: [:name, :age]).require(:user)`' do
       expect_no_offenses(<<~RUBY)
         params.permit(unmatch_require_param: [:name, :age]).require(:user)


### PR DESCRIPTION
When `permit` receives a single dynamic argument, such as `params.require(:user).permit(policy.permitted_attributes)`, the cop wrapped it in one more array level and produced `params.expect(user: [permitted])`. That raises `ActionController::ParameterMissing` at runtime when the argument returns an array of attributes.

There is no single rewrite that is correct in every case: the argument may return either a list of attributes (which needs to be splatted) or a nested hash (which must stay wrapped), and that cannot be determined statically. So such calls are no longer flagged, instead of being autocorrected into broken code.

Fixes #1574.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
