### PR TITLE
Allow `Rails.env.local?` in `Rails/Env`

### DIFF
--- a/changelog/change_allow_rails_env_local_in_rails_env.md
+++ b/changelog/change_allow_rails_env_local_in_rails_env.md
@@ -1,0 +1,1 @@
+* [#1617](https://github.com/rubocop/rubocop-rails/pull/1617): Allow `Rails.env.local?` in `Rails/Env`. ([@corsonknowles][])

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -2199,18 +2199,28 @@ enum status: [:active, :archived]
 
 Checks for usage of `Rails.env` which can be replaced with Feature Flags
 
+The cop does not flag `Rails.env.local?`, the built-in alias for
+"development or test" introduced in Rails 7.1. Unlike per-environment
+predicates such as `development?` or `production?`, `local?` expresses
+the intent of guarding code that must only ever run in development or
+test (sanity checks, devtools, seed data) rather than gating an
+environment rollout, so a Feature Flag is not a suitable replacement.
+
 [#examples-railsenv]
 === Examples
 
 [source,ruby]
 ----
 # bad
-Rails.env.production? || Rails.env.local?
+Rails.env.production? || Rails.env.development?
 
 # good
 if FeatureFlag.enabled?(:new_feature)
   # new feature code
 end
+
+# good
+raise 'This should never run in production' unless Rails.env.local?
 ----
 
 [#railsenvlocal]

--- a/lib/rubocop/cop/rails/env.rb
+++ b/lib/rubocop/cop/rails/env.rb
@@ -5,22 +5,34 @@ module RuboCop
     module Rails
       # Checks for usage of `Rails.env` which can be replaced with Feature Flags
       #
+      # The cop does not flag `Rails.env.local?`, the built-in alias for
+      # "development or test" introduced in Rails 7.1. Unlike per-environment
+      # predicates such as `development?` or `production?`, `local?` expresses
+      # the intent of guarding code that must only ever run in development or
+      # test (sanity checks, devtools, seed data) rather than gating an
+      # environment rollout, so a Feature Flag is not a suitable replacement.
+      #
       # @example
       #
       #   # bad
-      #   Rails.env.production? || Rails.env.local?
+      #   Rails.env.production? || Rails.env.development?
       #
       #   # good
       #   if FeatureFlag.enabled?(:new_feature)
       #     # new feature code
       #   end
       #
+      #   # good
+      #   raise 'This should never run in production' unless Rails.env.local?
+      #
       class Env < Base
         MSG = 'Use Feature Flags or config instead of `Rails.env`.'
         RESTRICT_ON_SEND = %i[env].freeze
         # This allow list is derived from:
         # (Rails.env.methods - Object.instance_methods).select { |m| m.to_s.end_with?('?') }
-        # and then removing the environment specific methods like development?, test?, production?, local?
+        # and then removing the environment specific methods like development?, test?, and production?.
+        # `local?` is kept on the allow list because it intentionally expresses
+        # "development or test" rather than a single environment rollout.
         ALLOWED_LIST = Set.new(
           %i[
             unicode_normalized?
@@ -38,6 +50,7 @@ module RuboCop
             valid_encoding?
             ascii_only?
             between?
+            local?
           ]
         ).freeze
 

--- a/spec/rubocop/cop/rails/env_spec.rb
+++ b/spec/rubocop/cop/rails/env_spec.rb
@@ -35,6 +35,12 @@ RSpec.describe RuboCop::Cop::Rails::Env, :config do
     RUBY
   end
 
+  it 'does not register an offense for `Rails.env.local?`' do
+    expect_no_offenses(<<~RUBY)
+      Rails.env.local?
+    RUBY
+  end
+
   it 'does not register an offense for unrelated config' do
     expect_no_offenses(<<~RUBY)
       Rails.environment


### PR DESCRIPTION
## Summary

Add `local?` to `Rails/Env`'s `ALLOWED_LIST` so `Rails.env.local?` is no longer flagged.

This follows the suggestion/request from @koic in #1617: rather than introduce a public `AllowedPredicates` option, simply add `local?` to the existing `ALLOWED_LIST` constant. (The two approaches could be complementary, but either will suffice).

`Rails.env.local?` is the built-in alias for "development or test" introduced in Rails 7.1. Unlike the per-environment predicates the cop targets (`development?`, `production?`, etc.), `local?` expresses the intent of guarding code that must only ever run in development or test (sanity checks, devtools, seed data) rather than gating an environment rollout, so a Feature Flag is not a suitable replacement.

This also resolves the conflict with [`Rails/EnvLocal`](https://docs.rubocop.org/rubocop-rails/latest/cops_rails.html#railsenvlocal), which autocorrects `Rails.env.development? || Rails.env.test?` to `Rails.env.local?` — previously `Rails/Env` would then flag the autocorrected result.

The cop description, examples, and generated documentation are updated accordingly (the previous `# bad` example used `Rails.env.local?`, which is now allowed).

## Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote good commit messages.
* [ ] Commit message starts with `[Fix #issue-number]` (no related issue).
* [x] Feature branch is up-to-date with `master`.
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`.
* [x] Added an entry (file) to the changelog folder.
* [x] If this is a new cop, consider making a corresponding update to the Rails Style Guide (N/A — existing cop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)