### PR TITLE
[Fix #1379] Fix a false positive for `Rails/SaveBang` when a persist method is the last expression in a multiline method or block

### DIFF
--- a/changelog/fix_an_incorrect_offense_for_rails_save_bang_in_a_multiline_method.md
+++ b/changelog/fix_an_incorrect_offense_for_rails_save_bang_in_a_multiline_method.md
@@ -1,0 +1,1 @@
+* [#1379](https://github.com/rubocop/rubocop-rails/issues/1379): Fix an incorrect offense for `Rails/SaveBang` when a persist method is the last expression in a multiline method or block. ([@aki77][])

--- a/lib/rubocop/cop/rails/save_bang.rb
+++ b/lib/rubocop/cop/rails/save_bang.rb
@@ -117,6 +117,7 @@ module RuboCop
       #   Services::Service::Mailer.update(message: 'Message')
       #   Service::Mailer::update
       #
+      # rubocop:disable Metrics/ClassLength
       class SaveBang < Base
         include NegativeConditional
         extend AutoCorrector
@@ -303,11 +304,18 @@ module RuboCop
         def implicit_return?(node)
           return false unless cop_config['AllowImplicitReturn']
 
-          node = assignable_node(node)
+          node = last_expression_in_begin(assignable_node(node))
           method, sibling_index = find_method_with_sibling_index(node.parent)
           return false unless method&.type?(:def, :any_block)
 
           method.children.size == node.sibling_index + sibling_index
+        end
+
+        # A multiline method or block body is wrapped in a `begin` node, so climb
+        # to it when the node is the last expression, to detect the implicit return.
+        def last_expression_in_begin(node)
+          node = node.parent while node.parent&.begin_type? && node.right_sibling.nil?
+          node
         end
 
         def find_method_with_sibling_index(node, sibling_index = 1)
@@ -345,6 +353,7 @@ module RuboCop
           node.first_argument.hash_type? || !node.first_argument.literal?
         end
       end
+      # rubocop:enable Metrics/ClassLength
     end
   end
 end

--- a/spec/rubocop/cop/rails/save_bang_spec.rb
+++ b/spec/rubocop/cop/rails/save_bang_spec.rb
@@ -655,6 +655,54 @@ RSpec.describe RuboCop::Cop::Rails::SaveBang, :config do
         RUBY
       end
     end
+
+    it "when using #{method} as the last method call in a multiline method" do
+      if allow_implicit_return
+        expect_no_offenses(<<~RUBY)
+          def foo
+            bar
+            object.#{method}
+          end
+        RUBY
+      else
+        expect_offense(<<~RUBY, method: method)
+          def foo
+            bar
+            object.#{method}
+                   ^{method} Use `#{method}!` instead of `#{method}` if the return value is not checked.
+          end
+        RUBY
+      end
+    end
+
+    it "when using #{method} as the last method call in a multiline block" do
+      if allow_implicit_return
+        expect_no_offenses(<<~RUBY)
+          objects.each do |object|
+            bar
+            object.#{method}
+          end
+        RUBY
+      else
+        expect_offense(<<~RUBY, method: method)
+          objects.each do |object|
+            bar
+            object.#{method}
+                   ^{method} Use `#{method}!` instead of `#{method}` if the return value is not checked.
+          end
+        RUBY
+      end
+    end
+
+    it "when using #{method} not as the last method call in a multiline method" do
+      expect_offense(<<~RUBY, method: method)
+        def foo
+          object.#{method}
+                 ^{method} Use `#{method}!` instead of `#{method}` if the return value is not checked.
+          bar
+        end
+      RUBY
+    end
   end
 
   described_class::MODIFY_PERSIST_METHODS.each do |method|


### PR DESCRIPTION
This fixes the false positive reported in #1379.

With `AllowImplicitReturn: true` (the default), `Rails/SaveBang` treats a persist method (`save`, `update`, etc.) as safe when it is the implicit return value of a method or block. However, when the method/block body has **multiple lines**, the statements are wrapped in a `begin` node by the parser. The previous implementation looked at the immediate parent of the call, found the `begin` node (which is neither a `def` nor a block), and incorrectly reported an offense.

```ruby
# This used to be flagged even though `object.save` is the implicit return value:
def foo
  bar

  object.save
end
```

This PR adds `last_expression_in_begin`, which climbs from the call up through any enclosing `begin` node as long as it is the last expression, so the implicit return is detected for multiline bodies just as it already was for single-line ones.

The fix is scoped to the issue: a persist method that is the *direct* last expression of a multiline method or block. Implicit returns nested inside `if`/`case`/`rescue` were not detected before and remain out of scope (unchanged behavior).

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).
