### PR TITLE
Fix false negatives in `Rails/SafeNavigation`

### DIFF
--- a/changelog/change_make_rails_safe_navigation_aware_of_operator_methods.md
+++ b/changelog/change_make_rails_safe_navigation_aware_of_operator_methods.md
@@ -1,0 +1,1 @@
+* [#1641](https://github.com/rubocop/rubocop-rails/pull/1641): Fix false negatives in `Rails/SafeNavigation` when using `try`/`try!` with operator methods such as `[]`, `[]=`, and `==`. ([@koic][])

--- a/lib/rubocop/cop/rails/safe_navigation.rb
+++ b/lib/rubocop/cop/rails/safe_navigation.rb
@@ -12,8 +12,8 @@ module RuboCop
       #   foo.try!(:bar)
       #   foo.try!(:bar, baz)
       #   foo.try!(:bar) { |e| e.baz }
-      #
       #   foo.try!(:[], 0)
+      #   foo.try!(:==, baz)
       #
       #   # good
       #   foo.try(:bar)
@@ -23,6 +23,8 @@ module RuboCop
       #   foo&.bar
       #   foo&.bar(baz)
       #   foo&.bar { |e| e.baz }
+      #   foo&.[](0)
+      #   foo&.==(baz)
       #
       # @example ConvertTry: true
       #   # bad
@@ -32,11 +34,15 @@ module RuboCop
       #   foo.try(:bar)
       #   foo.try(:bar, baz)
       #   foo.try(:bar) { |e| e.baz }
+      #   foo.try(:[], 0)
+      #   foo.try(:==, baz)
       #
       #   # good
       #   foo&.bar
       #   foo&.bar(baz)
       #   foo&.bar { |e| e.baz }
+      #   foo&.[](0)
+      #   foo&.==(baz)
       class SafeNavigation < Base
         include RangeHelp
         extend AutoCorrector
@@ -58,11 +64,16 @@ module RuboCop
         def on_send(node)
           try_call(node) do |try_method, dispatch|
             return if try_method == :try && !cop_config['ConvertTry']
-            return unless dispatch.sym_type? && dispatch.value.match?(/\w+[=!?]?/)
+            return unless dispatch.sym_type?
+            # When a `try` is nested in another `try`'s argument, correcting both at once
+            # produces overlapping replacements. Correct the outer one first and defer the
+            # inner one to a subsequent pass.
+            return if part_of_ignored_node?(node)
 
             add_offense(node, message: format(MSG, try: try_method)) do |corrector|
               autocorrect(corrector, node)
             end
+            ignore_node(node)
           end
         end
 
@@ -85,13 +96,19 @@ module RuboCop
         def replacement(method, params)
           new_params = params.map(&:source).join(', ')
 
-          if method.end_with?('=')
+          if setter_method?(method)
             "&.#{method[0...-1]} = #{new_params}"
           elsif params.empty?
             "&.#{method}"
           else
             "&.#{method}(#{new_params})"
           end
+        end
+
+        # Operator methods such as `==` and `[]=` also end with `=`, but they are not setters
+        # and must keep the explicit call form (e.g. `&.==(bar)`, `&.[]=(key, value)`).
+        def setter_method?(method)
+          method.match?(/\A\w+=\z/)
         end
       end
     end

--- a/spec/rubocop/cop/rails/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/rails/safe_navigation_spec.rb
@@ -50,9 +50,10 @@ RSpec.describe RuboCop::Cop::Rails::SafeNavigation, :config do
         it_behaves_like 'offense', 'try! with a question method', 'try!', '(:something?)'
         it_behaves_like 'offense', 'try! with a bang method', 'try!', '(:something!)'
 
-        it_behaves_like 'accepts', 'try! used to call an enumerable accessor', 'foo.try!(:[], :bar)'
-        it_behaves_like 'accepts', 'try! with ==', 'foo.try!(:==, bar)'
-        it_behaves_like 'accepts', 'try! with an operator', 'foo.try!(:+, bar)'
+        it_behaves_like 'offense', 'try! used to call an enumerable accessor', 'try!', '(:[], :bar)'
+        it_behaves_like 'offense', 'try! with ==', 'try!', '(:==, bar)'
+        it_behaves_like 'offense', 'try! with an operator', 'try!', '(:+, bar)'
+
         it_behaves_like 'accepts', 'try! with a method stored as a variable',
                         ['bar = :==',
                          'foo.try!(baz, bar)'].join("\n")
@@ -70,6 +71,10 @@ RSpec.describe RuboCop::Cop::Rails::SafeNavigation, :config do
     end
 
     it_behaves_like 'autocorrect', 'try! a single parameter', 'foo.try!(:thing=, bar)', 'foo&.thing = bar'
+    it_behaves_like 'autocorrect', 'try! with an indexer', 'foo.try!(:[], :bar)', 'foo&.[](:bar)'
+    it_behaves_like 'autocorrect', 'try! with an indexer assignment', 'foo.try!(:[]=, :x, :y)', 'foo&.[]=(:x, :y)'
+    it_behaves_like 'autocorrect', 'try! with ==', 'foo.try!(:==, bar)', 'foo&.==(bar)'
+    it_behaves_like 'autocorrect', 'try! with an operator', 'foo.try!(:+, bar)', 'foo&.+(bar)'
     it_behaves_like 'autocorrect', 'try! a single parameter', '[1, 2].try!(:join)', '[1, 2]&.join'
     it_behaves_like 'autocorrect', 'try! with 2 parameters', '[1, 2].try!(:join, ",")', '[1, 2]&.join(",")'
     it_behaves_like 'autocorrect', 'try! with multiple parameters',
@@ -88,6 +93,20 @@ RSpec.describe RuboCop::Cop::Rails::SafeNavigation, :config do
                     ['[foo, bar]&.each_with_object([]) do |e, acc|',
                      '  acc << e.some_method',
                      'end'].join("\n")
+
+    # A `try` nested in another `try`'s argument used to make autocorrection emit overlapping
+    # replacements (`Parser::ClobberingError`). The outer call is corrected first and the inner
+    # one is left for the next pass, so a single pass no longer clobbers.
+    it 'corrects a try! nested in another try! argument without clobbering' do
+      expect_offense(<<~RUBY)
+        foo.try!(:[], bar.try!(:[], :baz))
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use safe navigation (`&.`) instead of `try!`.
+      RUBY
+
+      expect_correction(<<~RUBY, loop: false)
+        foo&.[](bar.try!(:[], :baz))
+      RUBY
+    end
   end
 
   context 'convert try and try!' do
@@ -113,9 +132,11 @@ RSpec.describe RuboCop::Cop::Rails::SafeNavigation, :config do
                          '  acc << e.some_method',
                          'end'].join("\n")
 
-        it_behaves_like 'accepts', 'try! used to call an enumerable accessor', 'foo.try!(:[], :bar)'
+        it_behaves_like 'offense', 'try! used to call an enumerable accessor', 'try!', '(:[], :bar)'
 
         it_behaves_like 'autocorrect', 'try! a single parameter', '[1, 2].try!(:join)', '[1, 2]&.join'
+        it_behaves_like 'autocorrect', 'try! with an indexer', 'foo.try!(:[], :bar)', 'foo&.[](:bar)'
+        it_behaves_like 'autocorrect', 'try! with ==', 'foo.try!(:==, bar)', 'foo&.==(bar)'
         it_behaves_like 'autocorrect', 'try! with 2 parameters', '[1, 2].try!(:join, ",")', '[1, 2]&.join(",")'
         it_behaves_like 'autocorrect', 'try! with multiple parameters',
                         '[1, 2].try!(:join, bar, baz)', '[1, 2]&.join(bar, baz)'
@@ -145,9 +166,11 @@ RSpec.describe RuboCop::Cop::Rails::SafeNavigation, :config do
                          '  acc << e.some_method',
                          'end'].join("\n")
 
-        it_behaves_like 'accepts', 'try! used to call an enumerable accessor', 'foo.try!(:[], :bar)'
+        it_behaves_like 'offense', 'try used to call an enumerable accessor', 'try', '(:[], :bar)'
 
         it_behaves_like 'autocorrect', 'try a single parameter', '[1, 2].try(:join)', '[1, 2]&.join'
+        it_behaves_like 'autocorrect', 'try with an indexer', 'foo.try(:[], :bar)', 'foo&.[](:bar)'
+        it_behaves_like 'autocorrect', 'try with ==', 'foo.try(:==, bar)', 'foo&.==(bar)'
         it_behaves_like 'autocorrect', 'try with 2 parameters', '[1, 2].try(:join, ",")', '[1, 2]&.join(",")'
         it_behaves_like 'autocorrect', 'try with multiple parameters',
                         '[1, 2].try(:join, bar, baz)', '[1, 2]&.join(bar, baz)'


### PR DESCRIPTION
`Rails/SafeNavigation` previously left `try`/`try!` calls untouched when the dispatched method was an operator such as `[]`, `[]=`, or `==`. As a result, expressions like `h.try(:[], :k)` could not be rewritten without `try`, even though `h&.[](:k)` is an equivalent safe navigation form.

This makes the cop convert these too:

```ruby
# before (not flagged)
foo.try(:[], :bar)
foo.try(:[]=, :bar, :baz)
foo.try(:==, baz)

# after
foo&.[](:bar)
foo&.[]=(:bar, :baz)
foo&.==(baz)
```

`&.dig` is intentionally not used as the replacement for `[]`, because `dig` is only defined on a subset of receivers (Hash, Array, Struct), so `String#[]` or `MatchData#[]` would change behavior. The faithful `&.[]` call form is used instead.

Operator methods such as `==` and `[]=` also end with `=`, so the setter detection is tightened to word-named setters (`/\A\w+=\z/`) to keep them in the explicit call form rather than the `&.name = value` sugar.

Methods passed as a variable rather than a symbol literal remain unconverted, as before.

Because `[]` access is commonly nested (e.g. `a.try(:[], b.try(:[], :k))`), correcting the outer and inner calls in the same pass would produce overlapping replacements and raise `Parser::ClobberingError`. The outer call is now corrected first via `ignore_node`, deferring the inner call to the next autocorrection pass.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
