### PR TITLE
Fix a false negative for `Rails/SafeNavigation`

### DIFF
--- a/changelog/fix_a_false_negative_for_rails_safe_navigation_with_symbol_to_proc.md
+++ b/changelog/fix_a_false_negative_for_rails_safe_navigation_with_symbol_to_proc.md
@@ -1,0 +1,1 @@
+* [#1642](https://github.com/rubocop/rubocop-rails/pull/1642): Fix a false negative for `Rails/SafeNavigation` when using `try`/`try!` with a symbol to proc such as `foo.try(&:bar)`. ([@koic][])

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -6345,8 +6345,10 @@ if the target Ruby version is set to 2.3+
 foo.try!(:bar)
 foo.try!(:bar, baz)
 foo.try!(:bar) { |e| e.baz }
+foo.try!(&:bar)
 
 foo.try!(:[], 0)
+foo.try!(:==, baz)
 
 # good
 foo.try(:bar)
@@ -6356,6 +6358,8 @@ foo.try(:bar) { |e| e.baz }
 foo&.bar
 foo&.bar(baz)
 foo&.bar { |e| e.baz }
+foo&.[](0)
+foo&.==(baz)
 ----
 
 [#converttry_-true-railssafenavigation]
@@ -6367,14 +6371,20 @@ foo&.bar { |e| e.baz }
 foo.try!(:bar)
 foo.try!(:bar, baz)
 foo.try!(:bar) { |e| e.baz }
+foo.try!(&:bar)
 foo.try(:bar)
 foo.try(:bar, baz)
 foo.try(:bar) { |e| e.baz }
+foo.try(&:bar)
+foo.try(:[], 0)
+foo.try(:==, baz)
 
 # good
 foo&.bar
 foo&.bar(baz)
 foo&.bar { |e| e.baz }
+foo&.[](0)
+foo&.==(baz)
 ----
 
 [#configurable-attributes-railssafenavigation]

--- a/lib/rubocop/cop/rails/safe_navigation.rb
+++ b/lib/rubocop/cop/rails/safe_navigation.rb
@@ -12,6 +12,8 @@ module RuboCop
       #   foo.try!(:bar)
       #   foo.try!(:bar, baz)
       #   foo.try!(:bar) { |e| e.baz }
+      #   foo.try!(&:bar)
+      #
       #   foo.try!(:[], 0)
       #   foo.try!(:==, baz)
       #
@@ -31,9 +33,11 @@ module RuboCop
       #   foo.try!(:bar)
       #   foo.try!(:bar, baz)
       #   foo.try!(:bar) { |e| e.baz }
+      #   foo.try!(&:bar)
       #   foo.try(:bar)
       #   foo.try(:bar, baz)
       #   foo.try(:bar) { |e| e.baz }
+      #   foo.try(&:bar)
       #   foo.try(:[], 0)
       #   foo.try(:==, baz)
       #
@@ -57,6 +61,11 @@ module RuboCop
           (send _ ${:try :try!} $_ ...)
         PATTERN
 
+        # Extracts the method name from a symbol-to-proc block argument, e.g. `:foo` from `try(&:foo)`.
+        def_node_matcher :symbol_proc_method, <<~PATTERN
+          (block_pass (sym $_))
+        PATTERN
+
         def self.autocorrect_incompatible_with
           [Style::RedundantSelf]
         end
@@ -64,7 +73,7 @@ module RuboCop
         def on_send(node)
           try_call(node) do |try_method, dispatch|
             return if try_method == :try && !cop_config['ConvertTry']
-            return unless dispatch.sym_type?
+            return unless dispatch.sym_type? || symbol_proc_method(dispatch)
             # When a `try` is nested in another `try`'s argument, correcting both at once
             # produces overlapping replacements. Correct the outer one first and defer the
             # inner one to a subsequent pass.
@@ -81,7 +90,6 @@ module RuboCop
 
         def autocorrect(corrector, node)
           method_node, *params = *node.arguments
-          method = method_node.source[1..]
 
           range = if node.receiver
                     range_between(node.loc.dot.begin_pos, node.source_range.end_pos)
@@ -90,10 +98,13 @@ module RuboCop
                     node
                   end
 
-          corrector.replace(range, replacement(method, params))
+          corrector.replace(range, replacement(method_node, params))
         end
 
-        def replacement(method, params)
+        def replacement(method_node, params)
+          return "&.#{symbol_proc_method(method_node)}" if method_node.block_pass_type?
+
+          method = method_node.source[1..]
           new_params = params.map(&:source).join(', ')
 
           if setter_method?(method)

--- a/spec/rubocop/cop/rails/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/rails/safe_navigation_spec.rb
@@ -49,11 +49,13 @@ RSpec.describe RuboCop::Cop::Rails::SafeNavigation, :config do
                          'end'].join("\n")
         it_behaves_like 'offense', 'try! with a question method', 'try!', '(:something?)'
         it_behaves_like 'offense', 'try! with a bang method', 'try!', '(:something!)'
+        it_behaves_like 'offense', 'try! with a symbol to proc', 'try!', '(&:something)'
 
         it_behaves_like 'offense', 'try! used to call an enumerable accessor', 'try!', '(:[], :bar)'
         it_behaves_like 'offense', 'try! with ==', 'try!', '(:==, bar)'
         it_behaves_like 'offense', 'try! with an operator', 'try!', '(:+, bar)'
 
+        it_behaves_like 'accepts', 'try! with a proc stored as a variable', 'foo.try!(&block)'
         it_behaves_like 'accepts', 'try! with a method stored as a variable',
                         ['bar = :==',
                          'foo.try!(baz, bar)'].join("\n")
@@ -75,6 +77,7 @@ RSpec.describe RuboCop::Cop::Rails::SafeNavigation, :config do
     it_behaves_like 'autocorrect', 'try! with an indexer assignment', 'foo.try!(:[]=, :x, :y)', 'foo&.[]=(:x, :y)'
     it_behaves_like 'autocorrect', 'try! with ==', 'foo.try!(:==, bar)', 'foo&.==(bar)'
     it_behaves_like 'autocorrect', 'try! with an operator', 'foo.try!(:+, bar)', 'foo&.+(bar)'
+    it_behaves_like 'autocorrect', 'try! with a symbol to proc', 'foo.try!(&:bar)', 'foo&.bar'
     it_behaves_like 'autocorrect', 'try! a single parameter', '[1, 2].try!(:join)', '[1, 2]&.join'
     it_behaves_like 'autocorrect', 'try! with 2 parameters', '[1, 2].try!(:join, ",")', '[1, 2]&.join(",")'
     it_behaves_like 'autocorrect', 'try! with multiple parameters',
@@ -165,12 +168,16 @@ RSpec.describe RuboCop::Cop::Rails::SafeNavigation, :config do
                         ['(:each_with_object, []) do |e, acc|',
                          '  acc << e.some_method',
                          'end'].join("\n")
+        it_behaves_like 'offense', 'try with a symbol to proc', 'try', '(&:something)'
 
         it_behaves_like 'offense', 'try used to call an enumerable accessor', 'try', '(:[], :bar)'
+
+        it_behaves_like 'accepts', 'try with a proc stored as a variable', 'foo.try(&block)'
 
         it_behaves_like 'autocorrect', 'try a single parameter', '[1, 2].try(:join)', '[1, 2]&.join'
         it_behaves_like 'autocorrect', 'try with an indexer', 'foo.try(:[], :bar)', 'foo&.[](:bar)'
         it_behaves_like 'autocorrect', 'try with ==', 'foo.try(:==, bar)', 'foo&.==(bar)'
+        it_behaves_like 'autocorrect', 'try with a symbol to proc', 'foo.try(&:bar)', 'foo&.bar'
         it_behaves_like 'autocorrect', 'try with 2 parameters', '[1, 2].try(:join, ",")', '[1, 2]&.join(",")'
         it_behaves_like 'autocorrect', 'try with multiple parameters',
                         '[1, 2].try(:join, bar, baz)', '[1, 2]&.join(bar, baz)'


### PR DESCRIPTION
`Rails/SafeNavigation` did not flag `try`/`try!` calls that pass a method as a symbol to proc, such as `foo.try(&:bar)`, even though they are equivalent to safe navigation:

```ruby
# bad
foo.try!(&:bar)
foo.try(&:bar)

# good
foo&.bar
```

`foo.try(&:bar)` passes `:bar.to_proc`, whose arity is not zero, so Active Support's `try` yields the receiver to it (calling `receiver.bar`) and returns `nil` when the receiver is `nil`, which is exactly what `foo&.bar` does.

Only a literal symbol to proc is converted. A block passed through a variable (`foo.try(&block)`) is left untouched because it cannot be rewritten as `&.method`: a zero-arity proc would be run via `instance_eval`, and otherwise the proc is called with the receiver.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
