### PR TITLE
[Fix #1599] Fix an incorrect autocorrect for `Rails/LinkToBlank`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_rails_link_to_blank.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_rails_link_to_blank.md
@@ -1,0 +1,1 @@
+* [#1599](https://github.com/rubocop/rubocop-rails/issues/1599): Fix an incorrect autocorrect for `Rails/LinkToBlank` when `Style/TrailingCommaInArguments` with `EnforcedStyleForMultiline: consistent_comma` adds a trailing comma, which produced a duplicate comma. ([@koic][])

--- a/lib/rubocop-rails.rb
+++ b/lib/rubocop-rails.rb
@@ -39,3 +39,11 @@ RuboCop::Cop::Style::RedundantSelf.singleton_class.prepend(
     end
   end
 )
+
+RuboCop::Cop::Style::TrailingCommaInArguments.singleton_class.prepend(
+  Module.new do
+    def autocorrect_incompatible_with
+      super.push(RuboCop::Cop::Rails::LinkToBlank)
+    end
+  end
+)

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -52,6 +52,28 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects `Rails/LinkToBlank` with `Style/TrailingCommaInArguments`' do
+    create_file('.rubocop.yml', <<~YAML)
+      Style/TrailingCommaInArguments:
+        EnforcedStyleForMultiline: consistent_comma
+    YAML
+
+    create_file('example.rb', <<~RUBY)
+      link_to('Click here', 'https://www.example.com',
+        target: '_blank',
+        class: 'big'
+      )
+    RUBY
+
+    expect(cli.run(['-a', '--only', 'Rails/LinkToBlank,Style/TrailingCommaInArguments'])).to eq(0)
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      link_to('Click here', 'https://www.example.com',
+        target: '_blank',
+        class: 'big', rel: 'noopener',
+      )
+    RUBY
+  end
+
   it 'corrects `Style/HashExcept` with `TargetRubyVersion: 2.0`' do
     create_file('.rubocop.yml', <<~YAML)
       AllCops:


### PR DESCRIPTION
This PR fixes an incorrect autocorrect for `Rails/LinkToBlank` when `Style/TrailingCommaInArguments` with `EnforcedStyleForMultiline: consistent_comma` is enabled.

Both cops insert a comma at the same offset (after the last argument), which produced a duplicate comma and a syntax error:

```ruby
link_to('Click here', 'https://www.example.com',
  target: '_blank',
  class: 'big',, rel: 'noopener'
)
```

`Style/TrailingCommaInArguments` runs before `Rails/LinkToBlank`, so the incompatibility is declared on the former following the existing pattern in `lib/rubocop-rails.rb`.

Fixes #1599.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
