### PR TITLE
Fix a false negative for `Rails/ReversibleMigration` with `remove_index` operation

### DIFF
--- a/changelog/fix_a_false_negative_for_rails_reversible_migration_with_remove_index.md
+++ b/changelog/fix_a_false_negative_for_rails_reversible_migration_with_remove_index.md
@@ -1,0 +1,1 @@
+* [#1646](https://github.com/rubocop/rubocop-rails/pull/1646): Fix a false negative for `Rails/ReversibleMigration` when using `remove_index` without a column inside a `change_table` block. ([@ilianah][])

--- a/lib/rubocop/cop/rails/reversible_migration.rb
+++ b/lib/rubocop/cop/rails/reversible_migration.rb
@@ -294,12 +294,20 @@ module RuboCop
             false
           when :remove
             target_rails_version >= 6.1 && all_hash_key?(node.last_argument, :type)
+          when :remove_index
+            reversible_remove_index?(node)
           when :change_default, :change_column_default, :change_table_comment,
                :change_column_comment
             all_hash_key?(node.last_argument, :from, :to)
           else
             true
           end
+        end
+
+        def reversible_remove_index?(node)
+          return true if node.arguments.any? { |arg| !arg.hash_type? }
+
+          all_hash_key?(node.last_argument, :column)
         end
 
         def within_change_method?(node)

--- a/spec/rubocop/cop/rails/reversible_migration_spec.rb
+++ b/spec/rubocop/cop/rails/reversible_migration_spec.rb
@@ -309,6 +309,32 @@ RSpec.describe RuboCop::Cop::Rails::ReversibleMigration, :config do
         RUBY
       end
     end
+
+    context 'remove_index' do
+      it_behaves_like 'accepts', 't.remove_index (with column)', <<~RUBY
+        change_table :users do |t|
+          t.remove_index column: :email
+        end
+      RUBY
+
+      it_behaves_like 'accepts', 't.remove_index (with positional column)', <<~RUBY
+        change_table :users do |t|
+          t.remove_index :email
+        end
+      RUBY
+
+      it_behaves_like 'accepts', 't.remove_index (with positional column and options)', <<~RUBY
+        change_table :users do |t|
+          t.remove_index :email, if_exists: true
+        end
+      RUBY
+
+      it_behaves_like 'offense', 'change_table(with remove_index)', <<~RUBY
+        change_table :users do |t|
+          t.remove_index name: :index_users_on_email
+        end
+      RUBY
+    end
   end
 
   context 'remove_columns' do


### PR DESCRIPTION
When using `change_table` builder with `remove_index` as one of the operations, a `remove_index` action without defined columns is treated as reversible.

This is a false negative because reversing a `remove_index` requires the columns so the index can be rebuilt. Defining the name only raises `ActiveRecord::IrreversibleMigration` on down.

The equivalent top-level form, `remove_index :users, name: :index_users_on_email` is already correctly flagged as irreversible because it goes via a [different path](https://github.com/rubocop/rubocop-rails/blob/master/lib/rubocop/cop/rails/reversible_migration.rb#L270-L276) which handles that case

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
