### PR TITLE
[Fix] Fix a false negative for `Rails/EagerEvaluationLogMessage`

### DIFF
--- a/changelog/fix_a_false_negative_for_rails_eager_evaluation_log_message.md
+++ b/changelog/fix_a_false_negative_for_rails_eager_evaluation_log_message.md
@@ -1,0 +1,1 @@
+* [#1647](https://github.com/rubocop/rubocop-rails/pull/1647): Fix a false negative for `Rails/EagerEvaluationLogMessage` when the interpolated string is passed to `Rails.logger.debug` as the sole body of an enclosing block such as `each` or `tap`. ([@conwayje][])

--- a/lib/rubocop/cop/rails/eager_evaluation_log_message.rb
+++ b/lib/rubocop/cop/rails/eager_evaluation_log_message.rb
@@ -42,7 +42,7 @@ module RuboCop
         end
 
         def on_send(node)
-          return if node.parent&.block_type?
+          return if node.block_literal?
 
           interpolated_string_passed_to_debug(node) do |arguments|
             range = replacement_range(node)

--- a/spec/rubocop/cop/rails/eager_evaluation_log_message_spec.rb
+++ b/spec/rubocop/cop/rails/eager_evaluation_log_message_spec.rb
@@ -34,4 +34,51 @@ RSpec.describe RuboCop::Cop::Rails::EagerEvaluationLogMessage, :config do
       end
     RUBY
   end
+
+  it 'registers an offense when the interpolated string is passed to Rails.logger.debug as the sole body of a block' do
+    expect_offense(<<~'RUBY')
+      names.each do |name|
+        Rails.logger.debug "The name is #{name}"
+                           ^^^^^^^^^^^^^^^^^^^^^ Pass a block to `Rails.logger.debug`.
+      end
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      names.each do |name|
+        Rails.logger.debug { "The name is #{name}" }
+      end
+    RUBY
+  end
+
+  it 'registers an offense for a parenthesized call passed to Rails.logger.debug as the sole body of a block' do
+    expect_offense(<<~'RUBY')
+      names.each do |name|
+        Rails.logger.debug("The name is #{name}")
+                          ^^^^^^^^^^^^^^^^^^^^^^^ Pass a block to `Rails.logger.debug`.
+      end
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      names.each do |name|
+        Rails.logger.debug { "The name is #{name}" }
+      end
+    RUBY
+  end
+
+  it 'registers an offense when passed to Rails.logger.debug inside a block alongside other statements' do
+    expect_offense(<<~'RUBY')
+      names.each do |name|
+        process(name)
+        Rails.logger.debug "The name is #{name}"
+                           ^^^^^^^^^^^^^^^^^^^^^ Pass a block to `Rails.logger.debug`.
+      end
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      names.each do |name|
+        process(name)
+        Rails.logger.debug { "The name is #{name}" }
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Hi, all!  I'm working at Gusto (which has a very large Rails codebase, into the millions of lines) and was evaluating some cops for efficiency gains the other day.  `Rails/EagerEvaluationLogMessage` is near the top of that list, so I checked a few log lines in the codebase to see if they conformed, and found a few examples that didn't, concluding we must not have the cop enabled yet.  Digging a bit more, I surprisingly found that the cop _was_ enabled, and we still had things that -- to my eye -- seemed to be violations!

After digging a bit more, I realized a pattern.  All of the violations seemed to be in a context like this:

```
some_variable_having_a_block_passing_method_called_on_it.each do |block_variable|
  Rails.logger.warn("I am the only line in this block, and I have an #{arbitrary_variable}")
end
```

Assuming this was a false negative, I went down the stack until I found what I believe to be the culprit, which was the `node.parent&.block_type?` check in `#on_send`.  Further details below.

**Note:** This is my first contribution to Rubocop, so please let me know if I've done something wrong or missed any steps from the contribution guide.  Thank you!

## Summary

`Rails/EagerEvaluationLogMessage` has a false negative which fails to flag an interpolated string passed to `Rails.logger.debug` when that call is the **sole body of an enclosing block** (`each`, `tap`, `loop`, etc.).

```ruby
# not flagged today, but should be, as the string is still eagerly evaluated
names.each do |name|
  Rails.logger.debug "The name is #{name}"
end
```

### Root cause

The cop guards against re-flagging a `Rails.logger.debug { ... }` call that already passes a block:

```ruby
def on_send(node)
  return if node.parent&.block_type?
```

`node.parent&.block_type?` is meant to mean "this debug call has a block", but it is also `true` when the debug call is the body of some *other* block — there, the `send` node's parent is the enclosing block node, even though the debug call itself has no block. So any `Rails.logger.debug "..."` that happens to be the lone statement in an `each`/`tap`/etc. block is skipped (but ideally should not be skipped).

### Fix

Guard on `node.block_literal?` instead, which is true only when the debug call *itself* owns a block literal. Case A (`Rails.logger.debug { ... }` / `do...end`) is still correctly skipped; the sole-body-of-a-block case is now flagged and autocorrected to the block form.

To the best of my knowledge, this PR will:
* Maintain **all** previous violations / still mark them as violations
* Correctly mark what were previously false negatives as violations

## Before submitting

- [x] Added tests (offense + autocorrect for both the non-parenthesized and parenthesized sole-body-of-a-block cases; existing "debug owns the block" no-offense case still passes).
- [x] Added a changelog entry.
- [x] `bundle exec rake` passes (specs + internal RuboCop).
