### PR TITLE
[Fix #1164] Preserve comments when autocorrecting Rails/Delegate

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_rails_delegate_with_comments.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_rails_delegate_with_comments.md
@@ -1,0 +1,1 @@
+* [#1164](https://github.com/rubocop/rubocop-rails/issues/1164): Fix an incorrect autocorrect for `Rails/Delegate` that deleted comments inside the delegator method body. ([@vaidehijoshi][])

--- a/lib/rubocop/cop/rails/delegate.rb
+++ b/lib/rubocop/cop/rails/delegate.rb
@@ -88,8 +88,24 @@ module RuboCop
           add_offense(node.loc.keyword) do |corrector|
             receiver = determine_register_offense_receiver(node.body.receiver)
             delegation = build_delegation(node, receiver)
+            corrector.replace(node, build_replacement(node, delegation))
+          end
+        end
 
-            corrector.replace(node, delegation)
+        def build_replacement(node, delegation)
+          comments = body_comments(node)
+          return delegation if comments.empty?
+
+          indent = ' ' * node.loc.keyword.column
+          comments_str = comments.each_with_index.map do |c, i|
+            i.zero? ? c.text : "#{indent}#{c.text}"
+          end.join("\n")
+          "#{comments_str}\n#{indent}#{delegation}"
+        end
+
+        def body_comments(node)
+          processed_source.comments.select do |comment|
+            comment.loc.line.between?(node.first_line + 1, node.last_line - 1)
           end
         end
 

--- a/spec/rubocop/cop/rails/delegate_spec.rb
+++ b/spec/rubocop/cop/rails/delegate_spec.rb
@@ -354,6 +354,105 @@ RSpec.describe RuboCop::Cop::Rails::Delegate, :config do
     RUBY
   end
 
+  it 'autocorrects and preserves a comment in the method body' do
+    expect_offense(<<~RUBY)
+      def bar
+      ^^^ Use `delegate` to define delegations.
+        # foo has the bar we want
+        foo.bar
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # foo has the bar we want
+      delegate :bar, to: :foo
+    RUBY
+  end
+
+  it 'autocorrects and preserves multiple comments in the method body' do
+    expect_offense(<<~RUBY)
+      def bar
+      ^^^ Use `delegate` to define delegations.
+        # comment1
+        # comment2
+        foo.bar
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # comment1
+      # comment2
+      delegate :bar, to: :foo
+    RUBY
+  end
+
+  it 'autocorrects and preserves a comment below the delegation call' do
+    expect_offense(<<~RUBY)
+      def bar
+      ^^^ Use `delegate` to define delegations.
+        foo.bar
+        # trailing comment
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # trailing comment
+      delegate :bar, to: :foo
+    RUBY
+  end
+
+  it 'autocorrects and preserves a trailing inline comment in the method body' do
+    expect_offense(<<~RUBY)
+      def bar
+      ^^^ Use `delegate` to define delegations.
+        foo.bar # some note
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # some note
+      delegate :bar, to: :foo
+    RUBY
+  end
+
+  it 'autocorrects and preserves comments inside a class with correct indentation' do
+    expect_offense(<<~RUBY)
+      class A
+        def foo
+        ^^^ Use `delegate` to define delegations.
+          # comment1
+          # comment2
+          bar.foo
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class A
+        # comment1
+        # comment2
+        delegate :foo, to: :bar
+      end
+    RUBY
+  end
+
+  it 'autocorrects and preserves comments both above and below the delegation call' do
+    expect_offense(<<~RUBY)
+      def bar
+      ^^^ Use `delegate` to define delegations.
+        # comment above
+        foo.bar
+        # comment below
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      # comment above
+      # comment below
+      delegate :bar, to: :foo
+    RUBY
+  end
+
   it 'is disabled for controllers' do
     expect_no_offenses(<<~RUBY, "#{Bundler.root}/app/controllers/foo_controller.rb")
       class FooController


### PR DESCRIPTION
`Rails/Delegate` autocorrect was silently deleting comments inside the delegator method body. `corrector.replace` operates on the AST node range, and comments are not part of the AST, so they were simply dropped.

This fix collects comments from `processed_source.comments` that fall within the method body's line range and prepends them above the generated `delegate` line, re-indented to match the column of the `def` keyword. If there are no comments, the behavior is identical to before.

One note for reviewers: with this implementation, a trailing inline comment will be promoted to a standalone comment upon autocorrecting:
```ruby
def far
  foo.bar # my comment
end
```
would become:
```ruby
# my comment
delegate :bar, to: :foo
```

Whether or not the autocorrect should behave this way is perhaps up for debate. To me, it made more sense to have the autocorrect at least attempt to preserve to inline comment instead of omitting it (or not autocorrecting it at all). But let me know what you think of this approach!

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/