### PR TITLE
Allow frozen literal defaults in AttributeDefaultBlockValue

### DIFF
--- a/changelog/change_allow_frozen_literal_default_in_attribute_default_block_value.md
+++ b/changelog/change_allow_frozen_literal_default_in_attribute_default_block_value.md
@@ -1,0 +1,1 @@
+* [#1649](https://github.com/rubocop/rubocop-rails/pull/1649): Allow frozen array/hash literal (e.g. `[].freeze`, `{}.freeze`) as `:default` value in `Rails/AttributeDefaultBlockValue`. ([@kuboon][])

--- a/lib/rubocop/cop/rails/attribute_default_block_value.rb
+++ b/lib/rubocop/cop/rails/attribute_default_block_value.rb
@@ -29,6 +29,11 @@ module RuboCop
       #     attribute :roles, :string, array: true, default: -> { [] }
       #   end
       #
+      #   # good
+      #   class User < ApplicationRecord
+      #     attribute :roles, :string, array: true, default: [].freeze
+      #   end
+      #
       #   # bad
       #   class User < ApplicationRecord
       #     attribute :configuration, default: {}
@@ -71,10 +76,14 @@ module RuboCop
         PATTERN
 
         def_node_matcher :attribute, '(pair (sym :default) $_)'
+        def_node_matcher :frozen_literal_default?, <<~PATTERN
+          (send {(array) (hash)} :freeze)
+        PATTERN
 
         def on_send(node)
           default_attribute(node) do |attribute|
             value = attribute.children.last
+            return if frozen_literal_default?(value)
             return unless TYPE_OFFENDERS.any?(value.type)
 
             add_offense(value) do |corrector|

--- a/spec/rubocop/cop/rails/attribute_default_block_value_spec.rb
+++ b/spec/rubocop/cop/rails/attribute_default_block_value_spec.rb
@@ -21,6 +21,27 @@ RSpec.describe RuboCop::Cop::Rails::AttributeDefaultBlockValue, :config do
       RUBY
     end
 
+    it 'disallows frozen method call' do
+      expect_offense(<<~RUBY)
+        attribute :foo, :string, default: Foo.bar.freeze
+                                          ^^^^^^^^^^^^^^ #{message}
+      RUBY
+    end
+
+    it 'disallows non-empty frozen array literal' do
+      expect_offense(<<~RUBY)
+        attribute :roles, :string, array: true, default: [Foo.default_roles].freeze
+                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+      RUBY
+    end
+
+    it 'disallows non-empty frozen hash literal' do
+      expect_offense(<<~RUBY)
+        attribute :config, default: { a: [] }.freeze
+                                    ^^^^^^^^^^^^^^^^ #{message}
+      RUBY
+    end
+
     it 'disallows array literals' do
       expect_offense(<<~RUBY)
         attribute :foo, :string, array: true, default: []
@@ -99,6 +120,18 @@ RSpec.describe RuboCop::Cop::Rails::AttributeDefaultBlockValue, :config do
     it 'allows block' do
       expect_no_offenses(<<~RUBY)
         attribute :foo, :datetime, default: -> { Time.zone.now }
+      RUBY
+    end
+
+    it 'allows frozen array literal' do
+      expect_no_offenses(<<~RUBY)
+        attribute :foo, :string, array: true, default: [].freeze
+      RUBY
+    end
+
+    it 'allows frozen hash literal' do
+      expect_no_offenses(<<~RUBY)
+        attribute :foo, default: {}.freeze
       RUBY
     end
 


### PR DESCRIPTION
`Rails/AttributeDefaultBlockValue` flagged `attribute ... default: []`/`{}` unless wrapped in a proc, but frozen literals are already safe shared defaults. This change treats frozen array/hash literals as compliant while keeping non-literal method defaults block-only.

- **Cop behavior update**
  - Exempt `[].freeze` and `{}.freeze` from offenses.
  - Keep existing enforcement for dynamic defaults (including frozen method results like `Foo.bar.freeze`).

- **Spec coverage**
  - Added positive cases for frozen array/hash literal defaults.
  - Added a negative case to ensure `Foo.bar.freeze` is still flagged.

- **Documentation**
  - Updated `Rails/AttributeDefaultBlockValue` examples to include frozen literal defaults as valid usage.

```ruby
# now accepted
attribute :roles, :string, array: true, default: [].freeze
attribute :configuration, default: {}.freeze

# still flagged
attribute :roles, :string, array: true, default: Foo.default_roles.freeze
```
-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
